### PR TITLE
[feat] Initial adjustments for plugin to work with TK

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ Important: A caret is not a cursor, a cursor is what your mouse uses.. A caret i
 * Click on an authors colored icon block to follow that author as they move around a pad
 * I needed a third feature so let's go with free NFC Ring for anyone who spots this crazy "feature"
 
+## Customization
+
+By default, the caret indicator is rendered for 2 seconds, then it fades out. If you want to change this behavior, you can configure your `settings.json`:
+
+```
+  "ep_cursortrace":{
+    "fade_out_timeout": 2000 // in milliseconds. A 0 timeout means caret indicators are never hidden
+  }
+```
+
 ## TODO
 
 * Avoid race condition where the ACE object is sent and the cursor but the cursor arrives before the event

--- a/css.js
+++ b/css.js
@@ -1,0 +1,4 @@
+exports.eejsBlock_styles = function (hook_name, args, cb) {
+  args.content = args.content + "<link href='../static/plugins/ep_cursortrace/static/css/follow_user.css' rel='stylesheet'>";
+  return cb();
+}

--- a/ep.json
+++ b/ep.json
@@ -4,13 +4,14 @@
       "name": "cursortrace",
       "client_hooks": {
         "aceEditorCSS": "ep_cursortrace/static/js/css",
-        "aceInitInnerdocbodyHead": "ep_cursortrace/static/js/main:aceInitInnerdocbodyHead",
+        "aceInitInnerdocbodyHead": "ep_cursortrace/static/js/css",
         "postAceInit": "ep_cursortrace/static/js/main:postAceInit",
         "aceEditEvent": "ep_cursortrace/static/js/main:aceEditEvent",
         "handleClientMessage_CUSTOM": "ep_cursortrace/static/js/main",
-        "documentReady":"ep_cursortrace/static/js/main"
+        "documentReady":"ep_cursortrace/static/js/follow_user"
       },
       "hooks": {
+        "eejsBlock_styles": "ep_cursortrace/css",
         "handleMessage": "ep_cursortrace/handleMessage"
       }
     }

--- a/ep.json
+++ b/ep.json
@@ -8,6 +8,8 @@
         "postAceInit": "ep_cursortrace/static/js/main:postAceInit",
         "aceEditEvent": "ep_cursortrace/static/js/main:aceEditEvent",
         "handleClientMessage_CUSTOM": "ep_cursortrace/static/js/main",
+        "handleClientMessage_USER_NEWINFO": "ep_cursortrace/static/js/main",
+        "handleClientMessage_USER_LEAVE": "ep_cursortrace/static/js/main",
         "documentReady":"ep_cursortrace/static/js/follow_user"
       },
       "hooks": {

--- a/ep.json
+++ b/ep.json
@@ -12,6 +12,7 @@
       },
       "hooks": {
         "eejsBlock_styles": "ep_cursortrace/css",
+        "clientVars" : "ep_cursortrace/settings",
         "handleMessage": "ep_cursortrace/handleMessage"
       }
     }

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,7 @@
+settings = require('ep_etherpad-lite/node/utils/Settings');
+
+exports.clientVars = function (hook, context, cb) {
+  var fade_out_timeout = settings.ep_cursortrace ? settings.ep_cursortrace.fade_out_timeout : 2000;
+
+  return cb({ ep_cursortrace: { fade_out_timeout: fade_out_timeout } });
+};

--- a/static/css/cursortrace.css
+++ b/static/css/cursortrace.css
@@ -1,68 +1,32 @@
-.ghettoCursorXPos{
-  white-space:pre-wrap;
-  word-wrap:break-word;
-  z-index:99999;
-  background:red;
-  position:fixed;
-  top:80px;
-  left:33px;
-  margin-right:10px;
-  font-size:12px;
-  line-height:16px; /* Prolly breaks H1 etc */
-}
-
-.caretindicator{
+.caretindicator {
   max-width:300px;
-  padding:1px;
+  margin: -14px 0;
   position:absolute;
-  height:20px;
   opacity:1;
 }
 
-div.stickUp:before{
+.caretindicator:before {
   content: "";
   display: block;
   width: 2px;
-  height: 23px;
+  height: 26px;
   background-color: black;
-  opacity:.5;
-  margin-left:-2px;
-  margin-top:-6px;
+  opacity: .5;
 }
 
-div.stickDown:before{
-  content: "";
-  display: block;
-  width: 2px;
-  height: 23px;
-  background-color: black;
-  opacity:.5;
-  margin-left:-2px;
-  margin-top:0px;
-}
-
-p.stickUp{
+.caretindicator p {
   position:relative;
-  top:2px;
-  margin-top:-18px;
-  padding-left:4px;
-  padding-right:4px;
-}
-
-
-p.stickDown{
-  position:relative;
-  top:2px;
-  margin-top:-23px;
-  padding-left:4px;
-  padding-right:4px;
-}
-
-p.caretindicator{
-  position:relative;
-  top:2px;
   margin-top:-24px;
   padding-left:4px;
   padding-right:4px;
 }
 
+.caretindicator.stickDown {
+  margin-top: 14px;
+}
+.caretindicator.stickDown:before {
+  margin-top: -10px;
+}
+.caretindicator.stickDown p {
+  margin-top: -14px;
+}

--- a/static/css/follow_user.css
+++ b/static/css/follow_user.css
@@ -1,0 +1,29 @@
+#otheruserstable > tbody > tr > td > div:hover {
+  cursor: pointer;
+}
+
+.follow-user:before {
+  content: "\e80d";
+  color: #666;
+}
+
+/* based on .buttonicon styles */
+.follow-user {
+  width: 16px;
+  height: 16px;
+  display: inline-block;
+  vertical-align: middle;
+  border: none;
+  padding: 0;
+  background: none;
+  font-family: "fontawesome-etherpad";
+  font-size: 12px;
+  font-style: normal;
+  font-weight: normal;
+  cursor: pointer;
+}
+
+.follow-user::-moz-focus-inner {
+  padding: 0;
+  border: 0;
+}

--- a/static/css/inner_elements_position.css
+++ b/static/css/inner_elements_position.css
@@ -1,0 +1,17 @@
+/* Adjust position for all elements (SEs and SMs) inside the cloned helper line.
+   We need this because our divs on pad_inner are not one next to the other -- there's
+   a margin-top of the inner element between them.
+   To compensate that, we need to cancel those margins on the cloned line, so we get the
+   correct position. */
+#tempPosId episode_name,
+#tempPosId act_name,
+#tempPosId sequence_name,
+#tempPosId scene_name,
+#tempPosId heading,
+#tempPosId action,
+#tempPosId character,
+#tempPosId transition,
+#tempPosId shot {
+  /* need !important here because the element margin is set on "style" attrib */
+  margin-top: 0px !important;
+}

--- a/static/js/caret_position.js
+++ b/static/js/caret_position.js
@@ -16,8 +16,12 @@ var $ = require('ep_etherpad-lite/static/js/rjquery').$;
     5. Remove the clone, as it is not needed anymore.
 */
 exports.getCaretPosition = function(caretLine, caretColumn) {
+  // Are we ready to get caret position?
+  var $caretDiv = getPadInner().find('#innerdocbody > div:nth-child(' + caretLine + ')');
+  if ($caretDiv.length === 0) return;
+
   // Step 1:
-  var $clonedLine     = cloneLineWithStyle(caretLine);
+  var $clonedLine     = cloneLineWithStyle($caretDiv);
   var nodeInfo        = getNodeInfoWhereCaretIs(caretColumn, $clonedLine);
   var counter         = nodeInfo.counter;
   var cloneTextNode   = nodeInfo.node;
@@ -94,9 +98,7 @@ var splitNodeOnCaretPosition = function(cloneTextNode, counter, caretColumn) {
 }
 
 // Clone line with caret and copy its style
-var cloneLineWithStyle = function(caretLine) {
-  var $caretDiv = getPadInner().find('#innerdocbody > div:nth-child(' + caretLine + ')');
-
+var cloneLineWithStyle = function($caretDiv) {
   // Position of editor relative to client. Needed in final positioning
   var $padInnerFrame = getPadOuter().find('iframe[name="ace_inner"]');
   var innerEditorPosition = $padInnerFrame[0].getBoundingClientRect();

--- a/static/js/caret_position.js
+++ b/static/js/caret_position.js
@@ -1,0 +1,183 @@
+var $ = require('ep_etherpad-lite/static/js/rjquery').$;
+
+/*
+  Get position where caret should be placed -- on **pad outer**.
+  We cannot place it on pad inner because that messes up with ACE.
+
+  Strategy:
+    1. Create a clone (on pad outer) of the entire line where caret
+       is (on pad inner). Use same font, same size, etc, so we have
+       an exact copy of every single char of the line;
+    2. On the column where the caret is, insert a <span> -- to be
+       used as a reference for the position where caret should be;
+    3. Place the clone exactly on top of the original line, as if
+       one was overlapping the other;
+    4. Get the position on pad outer of the <span> created on step #2;
+    5. Remove the clone, as it is not needed anymore.
+*/
+exports.getCaretPosition = function(caretLine, caretColumn) {
+  // Step 1:
+  var $clonedLine     = cloneLineWithStyle(caretLine);
+  var nodeInfo        = getNodeInfoWhereCaretIs(caretColumn, $clonedLine);
+  var counter         = nodeInfo.counter;
+  var $cloneChildNode = nodeInfo.node;
+
+  var texts = getTextsBeforeAndAfterCaret($cloneChildNode, counter, caretColumn);
+  var textBeforeCaret = texts.textBeforeCaret;
+  var textAfterCaret = texts.textAfterCaret;
+
+  // Step 2:
+  var span = createHelperSpan();
+
+  // Remove the existing text
+  $cloneChildNode.text('');
+
+  // Reinsert the text, but with the additional node at caret position
+  $cloneChildNode[0].appendChild(document.createTextNode(textBeforeCaret)); // Insert text before caret
+  $cloneChildNode[0].appendChild(span); // Insert element at caret position
+  $cloneChildNode[0].appendChild(document.createTextNode(textAfterCaret)); // Insert text after caret
+
+  // Step 3:
+  // In order to see where the node we added is, we need to insert it into the document
+  $clonedLine.appendTo(getPadOuter().find('#outerdocbody'));
+
+  // Step 4:
+  var caretPosition = $(span).offset();
+  var scrollYPos = getPadOuter().scrollTop();
+
+  // Step 5:
+  $clonedLine.remove(); // Clean up again
+
+  return {
+    // Offset gives me the offset to the root document (not the iframe)
+    // so after scrolling down, top becomes less or even negative.
+    // So add the offset to get back where it belongs.
+    top: (caretPosition.top + scrollYPos),
+    left: caretPosition.left
+  };
+}
+
+var getNodeInfoWhereCaretIs = function(caretColumn, $caretDiv) {
+  // $textNodes holds all text nodes that are found inside the div
+  var $textNodes = $caretDiv.find('*').contents().filter(function() {
+    return this.nodeType === 3;
+  });
+
+  // Now we want to find the text node the caret is in
+  var counter = 0; // Holds the added length of text of all text nodes parsed so far
+  var $childNode = null; // The node caret is in
+
+  $textNodes.each(function(index,element) {
+    counter = counter + element.wholeText.length; //add up to the length of text nodes parsed
+    $childNode = $(element.parentNode);
+
+    // Found node where caret is
+    if(counter >= caretColumn) {
+      return false; //stop .each by returning false
+    }
+  });
+
+  if ($childNode === null) {
+    // There was no text node inside $caretDiv, so caret is on an empty line.
+    // Empty lines on Etherpad always have a <br>, so we get its parent.
+    // We cannot use br itself because if we insert a span inside the br we
+    // get weird positions on screen
+    $childNode = $caretDiv.find('br').parent();
+  }
+
+  return {
+    node: $childNode,
+    counter: counter,
+  };
+}
+
+var getTextsBeforeAndAfterCaret = function($cloneChildNode, counter, caretColumn) {
+  var targetNode = $cloneChildNode[0].childNodes[0]; // The subnode our caret is in
+  var targetNodeText = targetNode.wholeText || ''; // Text of the subnode our caret is in
+
+  // How many characters are between the start of the element and the caret?
+  var leftoverString = targetNodeText.length - (counter - caretColumn);
+
+  var textBeforeCaret = targetNodeText.substr(0, leftoverString);
+  var textAfterCaret = targetNodeText.substr(leftoverString);
+
+  return {
+    textBeforeCaret: textBeforeCaret,
+    textAfterCaret: textAfterCaret,
+  };
+}
+
+// Clone line with caret and copy its style
+var cloneLineWithStyle = function(caretLine) {
+  var $caretDiv = getPadInner().find('#innerdocbody > div:nth-child(' + caretLine + ')');
+
+  // Position of editor relative to client. Needed in final positioning
+  var $padInnerFrame = getPadOuter().find('iframe[name="ace_inner"]');
+  var innerEditorPosition = $padInnerFrame[0].getBoundingClientRect();
+
+  var childNodePosition = $caretDiv.position();
+  var computedCSS = window.getComputedStyle($caretDiv[0]);
+  var $clonedLine = $caretDiv.clone();
+
+  // Apply all styles to it
+  $clonedLine.attr('id','tempPosId'); // Change the id just in case...
+  $clonedLine.css({
+    position: 'absolute',
+    top: childNodePosition.top + innerEditorPosition.top + 'px',
+    left: childNodePosition.left + innerEditorPosition.left + 'px',
+    background: 'gray',
+    color: 'black',
+    display: 'block',
+    // get the correct position when caret is not on the first line of $caretDiv
+    "white-space":"normal",
+    "word-wrap":"break-word",
+  });
+
+  // Make sure $clonedLine and all its inner nodes have the same dimensions of
+  // the original nodes
+  copyStyles($caretDiv[0], $clonedLine[0]);
+  var $originalNodes = $caretDiv.find('*');
+  var $clonedNodes = $clonedLine.find('*');
+  for (var i = 0; i < $originalNodes.length; i++) {
+    copyStyles($originalNodes[i], $clonedNodes[i]);
+  }
+
+  return $clonedLine;
+}
+
+var copyStyles = function(fromNode, toNode) {
+  var computedCSS = window.getComputedStyle(fromNode);
+
+  $(toNode).css({
+    width:computedCSS.width,
+    height:computedCSS.height,
+    margin:computedCSS.margin,
+    padding:computedCSS.padding,
+    fontSize:computedCSS.fontSize,
+    fontWeight:computedCSS.fontWeight,
+    fontFamily:computedCSS.fontFamily,
+    lineHeight:computedCSS.lineHeight,
+  });
+}
+
+var createHelperSpan = function() {
+  var span = document.createElement('span');
+  // put some invisible content (vertical tab), so span is always displayed the same way
+  // (an empty span might be displayed above text on some scenarios)
+  span.appendChild(document.createTextNode('\x0b'));
+  return span;
+}
+
+// Easier access to outer pad
+var padOuter;
+var getPadOuter = function() {
+  padOuter = padOuter || $('iframe[name="ace_outer"]').contents();
+  return padOuter;
+}
+
+// Easier access to inner pad
+var padInner;
+var getPadInner = function() {
+  padInner = padInner || getPadOuter().find('iframe[name="ace_inner"]').contents();
+  return padInner;
+}

--- a/static/js/css.js
+++ b/static/js/css.js
@@ -1,8 +1,8 @@
-/*
-exports.eejsBlock_styles = function (hook_name, args, cb) {
-  args.content = args.content + "<link href='../static/plugins/ep_cursortrace/static/css/cursortrace.css' rel='stylesheet'>";
-  return cb();
+exports.aceEditorCSS = function(hook_name, cb){
+  return ["/ep_cursortrace/static/css/cursortrace.css"]; // inner pad CSS
 }
-*/
-exports.aceEditorCSS = function(hook_name, cb){return ["/ep_cursortrace/static/css/cursortrace.css"];} // inner pad CSS
 
+exports.aceInitInnerdocbodyHead = function(hook_name, args, cb) {
+  args.iframeHTML.push('<link rel="stylesheet" type="text/css" href="../static/plugins/ep_cursortrace/static/css/ace_inner.css"/>');
+  return cb();
+};

--- a/static/js/css.js
+++ b/static/js/css.js
@@ -1,5 +1,8 @@
 exports.aceEditorCSS = function(hook_name, cb){
-  return ["/ep_cursortrace/static/css/cursortrace.css"]; // inner pad CSS
+  return [
+    "/ep_cursortrace/static/css/cursortrace.css",
+    "/ep_cursortrace/static/css/inner_elements_position.css",
+  ]; // inner pad CSS
 }
 
 exports.aceInitInnerdocbodyHead = function(hook_name, args, cb) {

--- a/static/js/follow_user.js
+++ b/static/js/follow_user.js
@@ -1,0 +1,17 @@
+var $ = require('ep_etherpad-lite/static/js/rjquery').$;
+
+exports.documentReady = function() {
+  // Set the title
+  $('body').on('mouseover', '#otheruserstable > tbody > tr > td > div', function() {
+    $(this).attr('title', 'Watch this author');
+  });
+
+  // Watch / follow a user
+  $('body').on('click', '#otheruserstable > tbody > tr > td > div', function() {
+    $(this).toggleClass('follow-user');
+  });
+}
+
+exports.isFollowingUser = function(userId) {
+  return $('#otheruserstable > tbody > tr[data-authorid="' + userId + '"] > td > div').hasClass('follow-user');
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,9 +1,11 @@
 var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 var follow_user = require('./follow_user');
+var caretPosition = require('./caret_position');
 
+var SMILEY = "&#9785;"
+var INDICATOR_HEIGHT = 16;
 var initiated = false;
 var last = undefined;
-var globalKey = 0;
 
 exports.postAceInit = function(hook_name, args, cb) {
   initiated = true;
@@ -40,12 +42,16 @@ exports.className2Author = function(className)
 }
 
 exports.aceEditEvent = function(hook_name, args, cb) {
+  var callstack = args.callstack;
+  var rep = args.rep;
+
   // Note: last is a tri-state: undefined (when the pad is first loaded), null (no last cursor) and [line, col]
   // The AceEditEvent because it usually applies to selected items and isn't really so mucha bout current position.
-  var caretMoving = ((args.callstack.editEvent.eventType == "handleClick") || (args.callstack.type === "handleKeyEvent") || (args.callstack.type === "idleWorkTimer") );
+  var caretMoving = ((callstack.editEvent.eventType == "handleClick") || (callstack.type === "handleKeyEvent") || (callstack.type === "idleWorkTimer") );
   if (caretMoving && initiated){ // Note that we have to use idle timer to get the mouse position
-    var Y = args.rep.selStart[0];
-    var X = args.rep.selStart[1];
+    var Y = rep.selStart[0];
+    // Y might be a line with line attributes, so we need to ignore the '*' on the text
+    var X = rep.selStart[1] - rep.lines.atIndex(Y).lineMarker;
     if (!last || Y != last[0] || X != last[1]) { // If the position has changed
       var myAuthorId = pad.getUserId();
       var padId = pad.getPadId();
@@ -69,7 +75,8 @@ exports.aceEditEvent = function(hook_name, args, cb) {
 }
 
 exports.handleClientMessage_CUSTOM = function(hook, context, cb){
-  /* I NEED A REFACTOR, please */
+  if (!initiated) return;
+
   // A huge problem with this is that it runs BEFORE the dom has been updated so edit events are always late..
 
   var action = context.payload.action;
@@ -80,142 +87,55 @@ exports.handleClientMessage_CUSTOM = function(hook, context, cb){
   if(action === 'cursorPosition'){ // an author has sent this client a cursor position, we need to show it in the dom
     var y = context.payload.locationY + 1; // +1 as Etherpad line numbers start at 1
     var x = context.payload.locationX;
-    var $inner = $('iframe[name="ace_outer"]').contents().find('iframe');
-    var innerWidth = $inner.contents().find('#innerdocbody').width();
-    // it appears on apple devices this might not be set properly?
-    if($inner[0]){
-      var leftOffset = $inner[0].offsetLeft +3;
-    }else{
-      var leftOffset = 0;
-    }
-    var stickUp = false;
+    var position = caretPosition.getCaretPosition(y, x);
 
-    // Get the target Line
-    var div = $('iframe[name="ace_outer"]').contents().find('iframe').contents().find('#innerdocbody').find("div:nth-child("+y+")");
-    var divWidth = div.width();
+    // Author color
+    var users = pad.collabClient.getConnectedUsers();
+    $.each(users, function(user, value){
+      if(value.userId == authorId){
+        var authorClass = exports.getAuthorClassName(authorId);
+        var colors = pad.getColorPalette(); // support non set colors
+        var color = colors[value.colorId] || value.colorId; // Test for XSS
+        var $outBody = $('iframe[name="ace_outer"]').contents().find("#outerdocbody");
 
-    // Is the line visible yet?
-    if ( div.length !== 0 ) {
-      var top = $(div).offset().top -10; // A standard generic offset
-      // The problem we have here is we don't know the px X offset of the caret from the user
-      // Because that's a blocker for now lets just put a nice little div on the left hand side..
-      // SO here is how we do this..
-      // Get the entire string including the styling
-      // Put it in a hidden SPAN that has the same width as ace inner
-      // Delete everything after X chars
-      // Measure the new width -- This gives us the offset without modifying the ACE Dom
-      // Due to IE sucking this doesn't work in IE....
+        // Remove all divs that already exist for this author
+        $outBody.find(".caret-"+authorClass).remove();
 
-      // Get the HTML
-      var html = $(div).html();
+        // Location of stick direction IE up or down
+        var location = position.top >= INDICATOR_HEIGHT ? 'stickUp' : 'stickDown';
 
-      // build an ugly ID, makes sense to use authorId as authorId's cursor can only exist once
-      var authorWorker = "hiddenUgly" + exports.getAuthorClassName(authorId);
-
-      // if Div contains block attribute IE h1 or H2 then increment by the number
-      if ( $(div).children("span").length < 1 ){ x = x - 1; }// This is horrible but a limitation because I'm parsing HTML
-
-      // Get the new string but maintain mark up
-      var newText = html_substr(html, (x));
-
-      // A load of ugly HTML that can prolly be moved to CSS
-      var newLine = "<span style='width:"+divWidth+"px' id='" + authorWorker + "' class='ghettoCursorXPos'>"+newText+"</span>";
-
-      // Set the globalKey to 0, we use this when we wrap the objects in a datakey
-      globalKey = 0; // It's bad, messy, don't ever develop like this.
-
-      // Add the HTML to the DOM
-      $('iframe[name="ace_outer"]').contents().find('#outerdocbody').append(newLine);
-
-      // Get the worker element
-      var worker = $('iframe[name="ace_outer"]').contents().find('#outerdocbody').find("#" + authorWorker);
-
-      // Wrap the HTML in spans so we can find a char
-      $(worker).html(wrap($(worker)));
-      // console.log($(worker).html(), x);
-
-      // Get the Left offset of the x span
-      var span = $(worker).find("[data-key="+(x-1)+"]");
-
-      // Get the width of the element (This is how far out X is in px);
-      if(span.length !== 0){
-        var left = span.position().left;
-      }else{
-        var left = 0;
-      }
-
-      // Get the height of the element minus the inner line height
-      var height = worker.height(); // the height of the worker
-      top = top + height - span.height(); // plus the top offset minus the actual height of our focus span
-      if(top <= 0){  // If the tooltip wont be visible to the user because it's too high up
-        stickUp = true;
-        top = top + (span.height()*2);
-        if(top < 0){ top = 0; } // handle case where caret is in 0,0
-      }
-
-      // Add the innerdocbody offset
-      left = left + leftOffset;
-
-      // Add support for page view margins
-      var divMargin = parseCssInteger($(div).css("margin-left"));
-      var divPadding = parseCssInteger($(div).css("padding-left"));
-      var innerdocbodyMargin = parseCssInteger($(div).parent().css("margin-left"));
-      if((divMargin + divPadding + innerdocbodyMargin) > 0){
-        left = left + divMargin + divPadding;
-      }
-
-      // Remove the element
-      $('iframe[name="ace_outer"]').contents().find('#outerdocbody').contents().remove("#" + authorWorker);
-
-      // Author color
-      var users = pad.collabClient.getConnectedUsers();
-      $.each(users, function(user, value){
-        if(value.userId == authorId){
-          var authorClass = exports.getAuthorClassName(authorId);
-          var colors = pad.getColorPalette(); // support non set colors
-          var color = colors[value.colorId] || value.colorId; // Test for XSS
-          var $outBody = $('iframe[name="ace_outer"]').contents().find("#outerdocbody");
-
-          // Remove all divs that already exist for this author
-          $outBody.find(".caret-"+authorClass).remove();
-
-          // Location of stick direction IE up or down
-          var location = stickUp ? 'stickUp' : 'stickDown';
-
-          var authorName = decodeURI(escape(context.payload.authorName));
-          if(authorName == "null"){
-            var authorName = "&#9785;" // If the users username isn't set then display a smiley face
-          }
-
-          // Create a new Div for this author
-          var classes = "class='caretindicator " + location + " caret-" + authorClass + "'";
-          var styles = "style='height:16px;left:" + left + "px;top:" + top +"px;background-color:" + color + "'";
-          var $indicator = $("<div " + classes + " " + styles + " title="+authorName+"><p class='"+location+"'>"+authorName+"</p></div>");
-          $outBody.append($indicator);
-
-          // Are we following this author?
-          if(follow_user.isFollowingUser(value.userId)) {
-            if(top < 30) top = 0; // top line needs to be left visible
-            // scroll to the authors location
-            scrollTo(top);
-          }
-
-          // After a while, fade it out :)
-          setTimeout(function(){
-            $indicator.fadeOut(500, function(){
-              $indicator.remove();
-            });
-          }, 2000);
+        var authorName = decodeURI(escape(context.payload.authorName));
+        if(authorName == "null"){
+          var authorName = SMILEY; // If the users username isn't set then display a smiley face
         }
-      });
-    }
-  }
-}
 
-var parseCssInteger = function(str) {
-  str = str || '0px';
-  str = str.replace("px", "");
-  return parseInt(str);
+        // Create a new Div for this author
+        var classes = "class='caretindicator " + location + " caret-" + authorClass + "'";
+        var $indicator = $("<div " + classes + " title="+authorName+"><p>"+authorName+"</p></div>");
+        $indicator.css({
+          height:  INDICATOR_HEIGHT + "px",
+          left: position.left + "px",
+          top: position.top + "px",
+          "background-color": color,
+        });
+        $outBody.append($indicator);
+
+        // Are we following this author?
+        if(follow_user.isFollowingUser(value.userId)) {
+          if(position.top < 30) position.top = 0; // position.top line needs to be left visible
+          // scroll to the authors location
+          scrollTo(position.top);
+        }
+
+        // After a while, fade it out :)
+        setTimeout(function(){
+          $indicator.fadeOut(500, function(){
+            $indicator.remove();
+          });
+        }, 2000);
+      }
+    });
+  }
 }
 
 var scrollTo = function(top) {
@@ -227,70 +147,4 @@ var scrollTo = function(top) {
   $outerdoc.animate({scrollTop: newY});
   // works on Firefox & later versions of Chrome (>= 61)
   $outerdocHTML.animate({scrollTop: newY});
-}
-
-function html_substr( str, count ) {
-  if( browser.msie ) return ""; // IE can't handle processing any of the X position stuff so just return a blank string
-  // Basically the recursion makes IE run out of memory and slows a pad right down, I guess a way to fix this would be to
-  // only wrap the target / last span or something or stop it destroying and recreating on each change..
-  // Also IE can often inherit the wrong font face IE bold but not apply that to the whole document ergo getting teh width wrong
-  var div = document.createElement('div');
-  div.innerHTML = str;
-
-  walk( div, track );
-
-  function track( el ) {
-    if( count > 0 ) {
-      var len = el.data.length;
-      count -= len;
-      if( count <= 0 ) {
-        el.data = el.substringData( 0, el.data.length + count );
-      }
-    } else {
-      el.data = '';
-    }
-  }
-
-  function walk( el, fn ) {
-    var node = el.firstChild;
-    if(!node) return;
-    do {
-      if( node.nodeType === 3 ) {
-        fn(node);
-        //          Added this >>------------------------------------<<
-      } else if( node.nodeType === 1 && node.childNodes && node.childNodes[0] ) {
-        walk( node, fn );
-      }
-    } while( node = node.nextSibling );
-  }
-  return div.innerHTML;
-}
-
-function wrap(target) {
- var newtarget = $("<div></div>");
-  nodes = target.contents().clone(); // the clone is critical!
-
-  nodes.each(function() {
-    if (this.nodeType == 3) { // text
-      var newhtml = "";
-      var text = this.wholeText; // maybe "textContent" is better?
-      for (var i=0; i < text.length; i++) {
-        if (text[i] == ' '){
-          newhtml += "<span data-key="+globalKey+"> </span>";
-        }
-        else
-        {
-          newhtml += "<span data-key="+globalKey+">" + text[i] + "</span>";
-        }
-        globalKey++;
-      }
-      newtarget.append($(newhtml));
-    }
-    else { // recursion FTW!
-      // console.log("recursion"); // IE handles recursion badly
-      $(this).html(wrap($(this))); // This really hurts doing any sort of count..
-      newtarget.append($(this));
-    }
-  });
-  return newtarget.html();
 }

--- a/static/tests/frontend/specs/tests.js
+++ b/static/tests/frontend/specs/tests.js
@@ -1,0 +1,215 @@
+describe('ep_cursortrace - Basic Tests', function () {
+  var multipleUsers, originalDistance, originalPosition;
+
+  before(function(done) {
+    multipleUsers = ep_script_copy_cut_paste_test_helper.multipleUsers;
+    helper.newPad(function() {
+      // force setting to not hide caret indicators after some time, so tests
+      // can take a while and still be successful
+      makeSureCaretIndicatorWillBeAlwaysVisible();
+
+      // add some content to the pad
+      var $firstLine = helper.padInner$('div').first();
+      $firstLine.sendkeys('first line '.repeat(20));
+
+      multipleUsers.openSamePadOnWithAnotherUser(done);
+    });
+    this.timeout(60000);
+  });
+
+  it('shows caret indicator when another user joins the same pad', function(done) {
+    helper.waitFor(function() {
+      return getCaretIndicator().is(':visible');
+    }, 1900).done(done);
+  });
+
+  it('shows caret indicator for the user that was already on the pad', function(done) {
+    multipleUsers.performAsOtherUser(function(done) {
+      helper.waitFor(function() {
+        return getCaretIndicator().is(':visible');
+      }, 1900).done(done);
+    }, done);
+  });
+
+  context('when other user moves the caret', function() {
+    before(function(done) {
+      originalPosition = getCaretIndicatorPosition();
+
+      multipleUsers.performAsOtherUser(function(done) {
+        placeCaretAtEndOfLine();
+        done();
+      }, done);
+    });
+
+    it('updates the caret indicator for this user', function(done) {
+      waitForCaretIndicatorToMove(function() {
+        // caret is at the end of the line; caret indicator should be there too
+        var distance = getDistanceBetweenCaretIndicatorAndEndOfLine();
+        expect(distance.left).to.be(0);
+        expect(distance.top).to.be(0);
+        done();
+      });
+    });
+  });
+
+  context('when this user edits the line where caret of other user is', function() {
+    before(function() {
+      originalPosition = getCaretIndicatorPosition();
+
+      var $firstLine = helper.padInner$('div').first();
+      $firstLine.sendkeys('{selectall}{leftarrow}').sendkeys('!');
+    });
+
+    it('updates the caret indicator of the other user', function(done) {
+      waitForCaretIndicatorToMove(function() {
+        var distance = getDistanceBetweenCaretIndicatorAndEndOfLine();
+        expect(distance.left).to.be(0);
+        expect(distance.top).to.be(0);
+        done();
+      });
+    });
+  });
+
+  context('when other user formats part of the text', function() {
+    before(function(done) {
+      this.timeout(4000);
+
+      // [user 2] add bold to part of the middle of the line
+      multipleUsers.startActingLikeOtherUser();
+      selectTextInTheMiddleOfTheLine();
+      addBoldToSelectedText()
+
+      // [user 1] caret indicator should move to the bold text
+      multipleUsers.startActingLikeThisUser();
+      waitForCaretIndicatorToMove(function() {
+        originalPosition = getCaretIndicatorPosition();
+
+        // [user 2] go back to the end of line
+        multipleUsers.startActingLikeOtherUser();
+        placeCaretAtEndOfLine();
+
+        multipleUsers.startActingLikeThisUser();
+        done();
+      });
+    });
+
+    it('does not affect caret indicator for this user', function(done) {
+      waitForCaretIndicatorToMove(function() {
+        var distance = getDistanceBetweenCaretIndicatorAndEndOfLine();
+        expect(distance.left).to.be(0);
+        expect(distance.top).to.be(0);
+        done();
+      });
+    });
+  });
+
+  context('when other user places caret on an empty line', function() {
+    before(function(done) {
+      // [user 2] create an empty line at the end of pad
+      multipleUsers.startActingLikeOtherUser();
+      var $lines = helper.padInner$('div');
+      var originalNumberOfLines = $lines.length;
+      var $lastLine = $lines.last();
+      $lastLine.html($lastLine.html() + '<div/>');
+      // wait for line to be created
+      helper.waitFor(function() {
+        return helper.padInner$('div').length === originalNumberOfLines + 1;
+      }).done(function() {
+        // [user 1] get baseline position
+        multipleUsers.startActingLikeThisUser();
+        originalPosition = getCaretIndicatorPosition();
+
+        // [user 2] place caret on empty line
+        multipleUsers.startActingLikeOtherUser();
+        var $lastLine = helper.padInner$('div').last();
+        $lastLine.sendkeys('{selectall}{leftarrow}');
+
+        multipleUsers.startActingLikeThisUser();
+        done();
+      });
+    });
+
+    it('updates the caret indicator of the other user', function(done) {
+      waitForCaretIndicatorToMove(function() {
+        var $emptyLine = helper.padInner$('div').last();
+        var distance = getDistanceBetweenCaretIndicatorAndTarget($emptyLine);
+
+        expect(distance.left).to.be(0);
+        expect(distance.top).to.be(0);
+        done();
+      });
+    });
+  });
+
+  context('when other user leaves pad', function() {
+    before(function() {
+      multipleUsers.closePadForOtherUser();
+    });
+
+    it('removes the caret indicator', function(done) {
+      helper.waitFor(function() {
+        return !getCaretIndicator().is(':visible');
+      }, 1900).done(done);
+    });
+  });
+
+  /********************************** Helper Functions **********************************/
+  var makeSureCaretIndicatorWillBeAlwaysVisible = function() {
+    var pluginSettings = helper.padChrome$.window.clientVars.ep_cursortrace;
+    pluginSettings.fade_out_timeout = 0;
+  }
+
+  var getCaretIndicator = function() {
+    return helper.padOuter$('.caretindicator');
+  }
+
+  var getDistanceBetweenCaretIndicatorAndTarget = function($target, useEndOfTargetAsOrigin) {
+    var caretPosition = getCaretIndicatorPosition();
+    // create a temp element to get its position, then remove it
+    var $helperMark = $('<span>x</span>');
+    if (useEndOfTargetAsOrigin) {
+      $target.append($helperMark);
+    } else {
+      $target.prepend($helperMark);
+    }
+    var helperMarkPosition = $helperMark.position();
+
+    var top  = caretPosition.top  - helperMarkPosition.top;
+    var left = caretPosition.left - helperMarkPosition.left;
+
+    $helperMark.remove();
+
+    return { top: top, left: left };
+  }
+
+  var getCaretIndicatorPosition = function() {
+    return getCaretIndicator().position();
+  }
+
+  var getDistanceBetweenCaretIndicatorAndEndOfLine = function() {
+    var $endOfFirstLine = helper.padInner$('div').first().find('span').last();
+    return getDistanceBetweenCaretIndicatorAndTarget($endOfFirstLine, true);
+  }
+
+  var waitForCaretIndicatorToMove = function(done) {
+    helper.waitFor(function() {
+      var position = getCaretIndicatorPosition();
+      return position.left !== originalPosition.left || position.top !== originalPosition.top;
+    }).done(done).fail(done);
+  }
+
+  var placeCaretAtEndOfLine = function() {
+    var $firstLine = helper.padInner$('div').first();
+    $firstLine.sendkeys('{selectall}{rightarrow}');
+  }
+
+  var selectTextInTheMiddleOfTheLine = function() {
+    var $firstLine = helper.padInner$('div').first();
+    helper.selectLines($firstLine, $firstLine, 50, 60);
+  }
+
+  var addBoldToSelectedText = function() {
+    var $boldButton = helper.padChrome$('.buttonicon-bold');
+    $boldButton.click();
+  }
+});


### PR DESCRIPTION
- [feat] Create setting to allow caret to be permanently visible;
- [fix] Use same logic to calculate caret position as the one ep_autocomp has;
- [refactor] Extract styles to CSS files;
- [refactor] Code simplification;
- [test] Use helpers from `ep_script_copy_cut_paste` to test multiple users accessing the same pad;

This PR introduces some concepts that are particular to the Teksto context. This means we won't be able to (easily) send fixes to the original plugin from now on. 😞 
