### PR TITLE
[fix] Update caret position when SM is opened/closed

### DIFF
--- a/static/js/caret_position.js
+++ b/static/js/caret_position.js
@@ -1,4 +1,5 @@
 var $ = require('ep_etherpad-lite/static/js/rjquery').$;
+var utils = require('./utils');
 
 /*
   Get position where caret should be placed -- on **pad outer**.
@@ -17,7 +18,7 @@ var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 */
 exports.getCaretPosition = function(caretLine, caretColumn) {
   // Are we ready to get caret position?
-  var $caretDiv = getPadInner().find('#innerdocbody > div:nth-child(' + caretLine + ')');
+  var $caretDiv = utils.getPadInner().find('#innerdocbody > div:nth-child(' + caretLine + ')');
   if ($caretDiv.length === 0) return;
 
   // Step 1:
@@ -34,11 +35,11 @@ exports.getCaretPosition = function(caretLine, caretColumn) {
 
   // Step 3:
   // In order to see where the node we added is, we need to insert it into the document
-  $clonedLine.appendTo(getPadOuter().find('#outerdocbody'));
+  $clonedLine.appendTo(utils.getPadOuter().find('#outerdocbody'));
 
   // Step 4:
   var caretPosition = $(span).offset();
-  var scrollYPos = getPadOuter().scrollTop();
+  var scrollYPos = utils.getPadOuter().scrollTop();
 
   // Step 5:
   $clonedLine.remove(); // Clean up again
@@ -100,7 +101,7 @@ var splitNodeOnCaretPosition = function(cloneTextNode, counter, caretColumn) {
 // Clone line with caret and copy its style
 var cloneLineWithStyle = function($caretDiv) {
   // Position of editor relative to client. Needed in final positioning
-  var $padInnerFrame = getPadOuter().find('iframe[name="ace_inner"]');
+  var $padInnerFrame = utils.getPadOuter().find('iframe[name="ace_inner"]');
   var innerEditorPosition = $padInnerFrame[0].getBoundingClientRect();
 
   var childNodePosition = $caretDiv.position();
@@ -154,18 +155,4 @@ var createHelperSpan = function() {
   // (an empty span might be displayed above text on some scenarios)
   span.appendChild(document.createTextNode('\x0b'));
   return span;
-}
-
-// Easier access to outer pad
-var padOuter;
-var getPadOuter = function() {
-  padOuter = padOuter || $('iframe[name="ace_outer"]').contents();
-  return padOuter;
-}
-
-// Easier access to inner pad
-var padInner;
-var getPadInner = function() {
-  padInner = padInner || getPadOuter().find('iframe[name="ace_inner"]').contents();
-  return padInner;
 }

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -1,0 +1,22 @@
+var $ = require('ep_etherpad-lite/static/js/rjquery').$;
+
+// Easier access to outer pad
+var padOuter;
+exports.getPadOuter = function() {
+  padOuter = padOuter || $('iframe[name="ace_outer"]').contents();
+  return padOuter;
+}
+
+// Easier access to inner pad
+var padInner;
+exports.getPadInner = function() {
+  padInner = padInner || exports.getPadOuter().find('iframe[name="ace_inner"]').contents();
+  return padInner;
+}
+
+// Easier access to outer doc body
+var $outerDocBody;
+exports.getOuterDoc = function() {
+  $outerDocBody = $outerDocBody || exports.getPadOuter().find("#outerdocbody");
+  return $outerDocBody;
+}

--- a/static/tests/frontend/specs/_utils.js
+++ b/static/tests/frontend/specs/_utils.js
@@ -1,0 +1,98 @@
+var ep_cursortrace_test_helper = ep_cursortrace_test_helper || {};
+ep_cursortrace_test_helper.utils = {
+  failTest: function(msg) {
+    expect().fail(function() { return msg });
+  },
+
+  getLine: function(lineNum) {
+    return helper.padInner$('div').eq(lineNum);
+  },
+
+  openPadForMultipleUsers: function(test, createScript, done) {
+    helper.newPad(function() {
+      createScript(function() {
+        var utils = ep_cursortrace_test_helper.utils;
+
+        utils.speedUpCaretUpdate();
+
+        // force setting to not hide caret indicators after some time, so tests
+        // can take a while and still be successful
+        utils.makeSureCaretIndicatorWillBeAlwaysVisible();
+
+        ep_script_copy_cut_paste_test_helper.multipleUsers.openSamePadOnWithAnotherUser(done);
+      });
+    });
+
+    test.timeout(60000);
+  },
+
+  makeSureCaretIndicatorWillBeAlwaysVisible: function() {
+    var pluginSettings = helper.padChrome$.window.clientVars.ep_cursortrace;
+    pluginSettings.fade_out_timeout = 0;
+  },
+
+  speedUpCaretUpdate: function() {
+    var thisPlugin = helper.padChrome$.window.pad.plugins.ep_cursortrace;
+    thisPlugin.timeToUpdateCaretPosition = 0;
+
+    // There's a unique trigger for lines changed event (on ep_comments), we need to set
+    // the timeout there
+    var ep_comments_page = helper.padChrome$.window.pad.plugins.ep_comments_page;
+    ep_comments_page.commentHandler.lineChangeEventTriggerer.padChangedListener.timeout = 0;
+  },
+
+  getCaretIndicator: function() {
+    return helper.padOuter$('.caretindicator');
+  },
+
+  getDistanceBetweenCaretIndicatorAndTarget: function($target, useEndOfTargetAsOrigin) {
+    var caretPosition = ep_cursortrace_test_helper.utils.getCaretIndicatorPosition();
+    // create a temp element to get its position, then remove it
+    var $helperMark = $('<span>x</span>');
+    if (useEndOfTargetAsOrigin) {
+      $target.append($helperMark);
+    } else {
+      $target.prepend($helperMark);
+    }
+    var helperMarkPosition = $helperMark.position();
+
+    var top  = caretPosition.top  - helperMarkPosition.top;
+    var left = caretPosition.left - helperMarkPosition.left;
+
+    $helperMark.remove();
+
+    return { top: top, left: left };
+  },
+
+  getDistanceBetweenCaretIndicatorAndEndOfLine: function(lineNumber) {
+    var utils = ep_cursortrace_test_helper.utils;
+    var $endOfLine = utils.getLine(lineNumber).find('span').last();
+    return utils.getDistanceBetweenCaretIndicatorAndTarget($endOfLine, true);
+  },
+
+  getCaretIndicatorPosition: function() {
+    return ep_cursortrace_test_helper.utils.getCaretIndicator().position();
+  },
+
+  waitForCaretIndicatorToMove: function(originalPosition, done) {
+    helper.waitFor(function() {
+      var position = ep_cursortrace_test_helper.utils.getCaretIndicatorPosition();
+      return position.left !== originalPosition.left || position.top !== originalPosition.top;
+    }).done(done).fail(done);
+  },
+
+  executeAndWaitForCaretIndicatorToMove: function(execFunction, done) {
+    var utils = ep_cursortrace_test_helper.utils;
+    var originalPosition = utils.getCaretIndicatorPosition();
+    execFunction(function() {
+      utils.waitForCaretIndicatorToMove(originalPosition, done);
+    });
+  },
+
+  waitForCaretIndicatorToBeVisible: function(done) {
+    var utils = ep_cursortrace_test_helper.utils;
+    helper.waitFor(function() {
+      return utils.getCaretIndicator().is(':visible');
+    }, 1900).done(done);
+  },
+}

--- a/static/tests/frontend/specs/integration-ep_sm.js
+++ b/static/tests/frontend/specs/integration-ep_sm.js
@@ -1,0 +1,160 @@
+describe('ep_cursortrace - integration with ep_script_scene_marks', function () {
+  var utils, smUtils, multipleUsers;
+
+  var LINE_BEFORE_SM = 0;
+  var LINE_WITH_HEADING = 4;
+  var LINE_AFTER_SM = 6;
+
+  /*
+    Script lines:
+      LINE_BEFORE_SM
+      synopsis title
+      synopsis description
+      LINE_WITH_HEADING
+      LINE_AFTER_SM
+  */
+  var createScript = function(done) {
+    // add a SM, and some content before and after it
+    var sceneText = 'scene';
+    var firstLineText = 'first line '.repeat(10);
+    var lastLineText = 'last line '.repeat(10);
+
+    var lineBeforeSM = smUtils.action(firstLineText);
+    var lineAfterSM  = smUtils.action(lastLineText);
+    var synopsis     = smUtils.synopsis(sceneText);
+    var heading      = smUtils.heading(sceneText);
+    var separator    = smUtils.general('separator');
+
+    // add a separator between target lines and SM/heading, as lines adjacent to changed
+    // line are also updated
+    var script = lineBeforeSM + separator + synopsis + heading + separator + lineAfterSM;
+
+    smUtils.createScriptWith(script, lastLineText, done);
+  }
+
+  before(function(done) {
+    multipleUsers = ep_script_copy_cut_paste_test_helper.multipleUsers;
+    utils = ep_cursortrace_test_helper.utils;
+    smUtils = ep_script_scene_marks_test_helper.utils;
+
+    utils.openPadForMultipleUsers(this, createScript, function() {
+      // wait for both caret indicators to be shown
+      utils.waitForCaretIndicatorToBeVisible(function() {
+        multipleUsers.performAsOtherUser(utils.waitForCaretIndicatorToBeVisible, done);
+      });
+    });
+  });
+
+  context('when other user places caret on a SM hidden for this user', function() {
+    it('shows caret indicator on beginning of line with heading');
+  });
+
+  context('when other user places caret on a line before a SM hidden for this user', function() {
+    var moveCaret = function(done) {
+      multipleUsers.startActingLikeOtherUser();
+      var $line = utils.getLine(LINE_BEFORE_SM);
+      $line.sendkeys('{selectall}{rightarrow}');
+
+      multipleUsers.startActingLikeThisUser();
+      done();
+    }
+
+    it('updates the caret indicator for this user', function(done) {
+      utils.executeAndWaitForCaretIndicatorToMove(moveCaret, function() {
+        var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(LINE_BEFORE_SM);
+        expect(distance.left).to.be(0);
+        expect(distance.top).to.be(0);
+        done();
+      });
+    });
+
+    context('and this user opens the SM', function() {
+      var originalTimestamp;
+
+      before(function() {
+        originalTimestamp = utils.getCaretIndicator().attr('timestamp');
+        if (!originalTimestamp) {
+          utils.failTest('Timestamp not set on caret indicator');
+        }
+
+        smUtils.clickOnSceneMarkButtonOfLine(LINE_WITH_HEADING);
+      });
+
+      after(function() {
+        // close SM again
+        smUtils.clickOnSceneMarkButtonOfLine(LINE_WITH_HEADING);
+      });
+
+      it('does not update the caret indicator', function(done) {
+        helper.waitFor(function() {
+          var timestamp = utils.getCaretIndicator().attr('timestamp');
+          return timestamp !== originalTimestamp;
+        }, 1900).done(function() {
+          utils.failTest('Caret indicator was updated');
+        }).fail(function() {
+          // all set, no indicator was updated call. We can finish the test
+          done();
+        });
+      });
+
+      it('keeps the caret indicator on the right position', function(done) {
+        var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(LINE_BEFORE_SM);
+        expect(distance.left).to.be(0);
+        expect(distance.top).to.be(0);
+        done();
+      });
+    });
+  });
+
+  context('when other user places caret on a line after a SM hidden for this user', function() {
+    var moveCaret = function(done) {
+      multipleUsers.startActingLikeOtherUser();
+      var $line = utils.getLine(LINE_AFTER_SM);
+      $line.sendkeys('{selectall}{rightarrow}');
+
+      multipleUsers.startActingLikeThisUser();
+      done();
+    }
+
+    it('updates the caret indicator for this user', function(done) {
+      utils.executeAndWaitForCaretIndicatorToMove(moveCaret, function() {
+        var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(LINE_AFTER_SM);
+        expect(distance.left).to.be(0);
+        expect(distance.top).to.be(0);
+        done();
+      });
+    });
+
+    context('and this user opens the SM', function() {
+      var originalTimestamp;
+
+      before(function() {
+        originalTimestamp = utils.getCaretIndicator().attr('timestamp');
+        if (!originalTimestamp) {
+          utils.failTest('Timestamp not set on caret indicator');
+        }
+
+        smUtils.clickOnSceneMarkButtonOfLine(LINE_WITH_HEADING);
+      });
+
+      after(function() {
+        // close SM again
+        smUtils.clickOnSceneMarkButtonOfLine(LINE_WITH_HEADING);
+      });
+
+      it('updates the caret indicator', function(done) {
+        helper.waitFor(function() {
+          var timestamp = utils.getCaretIndicator().attr('timestamp');
+          return timestamp !== originalTimestamp;
+        }, 1900).done(done);
+      });
+
+      it('moves the caret indicator to the right position', function(done) {
+        var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(LINE_AFTER_SM);
+        expect(distance.left).to.be(0);
+        expect(distance.top).to.be(0);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This fix also work when for:

- changes on the browser zoom;
- editing a line and making it longer (and increasing its height on the screen), pulling the following lines further down;
- pasting content above the line where caret is.

Depends on [this PR of ep_comments](https://github.com/storytouch/ep_comments/pull/33).

Fixes bug https://trello.com/c/SgiGE4V0/1377.