### PR TITLE
Fix caret position on hidden lines

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -4,7 +4,6 @@
       "name": "cursortrace",
       "client_hooks": {
         "aceEditorCSS": "ep_cursortrace/static/js/css",
-        "aceInitInnerdocbodyHead": "ep_cursortrace/static/js/css",
         "postAceInit": "ep_cursortrace/static/js/main:postAceInit",
         "aceEditEvent": "ep_cursortrace/static/js/main:aceEditEvent",
         "handleClientMessage_CUSTOM": "ep_cursortrace/static/js/main",

--- a/static/css/ace_inner.css
+++ b/static/css/ace_inner.css
@@ -1,3 +1,0 @@
-.ep_cursortrace {
-  border-bottom: 5px solid red;
-}

--- a/static/css/cursortrace.css
+++ b/static/css/cursortrace.css
@@ -30,3 +30,8 @@
 .caretindicator.stickDown p {
   margin-top: -14px;
 }
+
+/* hide caret indicator when pad is disabled */
+#outerdocbody.disabled .caretindicator {
+  display: none;
+}

--- a/static/js/caret_indicator.js
+++ b/static/js/caret_indicator.js
@@ -1,0 +1,120 @@
+var $ = require('ep_etherpad-lite/static/js/rjquery').$;
+var utils = require('./utils');
+var hiddenLines = require('./hidden_lines');
+var caretPosition = require('./caret_position');
+
+var SMILEY = "&#9785;"
+var INDICATOR_HEIGHT = 16;
+
+exports.getAuthorClassName = function(author) {
+  if (!author) return;
+  return 'ep_cursortrace-' + author.replace(/[^a-y0-9]/g, function(c) {
+    if (c == '.') return '-';
+    return 'z' + c.charCodeAt(0) + 'z';
+  });
+}
+var getAuthorClassName = exports.getAuthorClassName;
+
+exports.className2Author = function(className) {
+  if (className.substring(0, 15) == "ep_cursortrace-") {
+    return className.substring(15).replace(/[a-y0-9]+|-|z.+?z/g, function(cc) {
+      if (cc == '-') {
+        return '.';
+      } else if (cc.charAt(0) == 'z') {
+        return String.fromCharCode(Number(cc.slice(1, -1)));
+      } else {
+        return cc;
+      }
+    });
+  }
+  return null;
+}
+
+exports.buildAndShowIndicators = function(caretLocations) {
+  var users = pad.collabClient.getConnectedUsers();
+
+  for (var i = 0; i < caretLocations.length; i++) {
+    var caretLocation = caretLocations[i];
+    var authorId = caretLocation.authorId;
+    var line     = caretLocation.line;
+    var column   = caretLocation.column;
+
+    // Don't show our own caret
+    if (pad.getUserId() === authorId) continue;
+
+    var visibleCaretPosition = hiddenLines.getVisiblePosition(line, column);
+    var position = caretPosition.getCaretPosition(visibleCaretPosition.line, visibleCaretPosition.column);
+    if (position) {
+      $.each(users, function(index, user) {
+        if (user.userId === authorId) {
+          var $indicator = buildIndicator(user, position);
+          showIndicator($indicator, authorId);
+          fadeOutCaretIndicator($indicator);
+        }
+      });
+    }
+  }
+}
+
+var getAuthorColor = function(author) {
+  var colors = pad.getColorPalette(); // support non set colors
+  var color = colors[author.colorId] || author.colorId; // Test for XSS
+  return color;
+}
+
+// If the name isn't set then display a smiley face
+var getAuthorName = function(user) {
+  return user.name ? decodeURI(escape(user.name)) : SMILEY;
+}
+
+var buildIndicator = function(user, position) {
+  // Location of stick direction IE up or down
+  var location = position.top >= INDICATOR_HEIGHT ? 'stickUp' : 'stickDown';
+  var color = getAuthorColor(user);
+  var authorName = getAuthorName(user);
+  var classes = "class='caretindicator " + location + "'";
+  var timestamp = Date.now();
+
+  // Create a new Div for this author
+  var $indicator = $("<div " + classes + " timestamp="+timestamp+"><p>"+authorName+"</p></div>");
+  $indicator.css({
+    height:  INDICATOR_HEIGHT + "px",
+    left: position.left + "px",
+    top: position.top + "px",
+    "background-color": color,
+  });
+
+  return $indicator;
+}
+
+var showIndicator = function($indicator, authorId) {
+  var $outerdoc = utils.getOuterDoc();
+
+  var authorClass = getAuthorClassName(authorId);
+  var authorClassName = "caret-" + authorClass;
+
+  // Remove all divs that already exist for this author
+  $outerdoc.find("." + authorClassName).remove();
+
+  $indicator.addClass(authorClassName);
+  $outerdoc.append($indicator);
+}
+
+var fadeOutCaretIndicator = function($indicator) {
+  if (clientVars.ep_cursortrace.fade_out_timeout) {
+    // After a while, fade it out :)
+    setTimeout(function(){
+      $indicator.fadeOut(500, function(){
+        $indicator.remove();
+      });
+    }, clientVars.ep_cursortrace.fade_out_timeout);
+  }
+}
+
+exports.removeCaretOf = function(userId) {
+  var authorClass = getAuthorClassName(userId);
+  var authorClassName = "caret-" + authorClass;
+
+  // remove caret indicator on editor
+  utils.getOuterDoc().find("." + authorClassName).remove();
+}

--- a/static/js/caret_indicator.js
+++ b/static/js/caret_indicator.js
@@ -1,4 +1,6 @@
 var $ = require('ep_etherpad-lite/static/js/rjquery').$;
+var Security = require('ep_etherpad-lite/static/js/security');
+
 var utils = require('./utils');
 var hiddenLines = require('./hidden_lines');
 var caretPosition = require('./caret_position');
@@ -6,28 +8,17 @@ var caretPosition = require('./caret_position');
 var SMILEY = "&#9785;"
 var INDICATOR_HEIGHT = 16;
 
-exports.getAuthorClassName = function(author) {
-  if (!author) return;
-  return 'ep_cursortrace-' + author.replace(/[^a-y0-9]/g, function(c) {
-    if (c == '.') return '-';
-    return 'z' + c.charCodeAt(0) + 'z';
+/*
+  Transform an authorId into a valid class name.
+    - replaces '.' on the id by a '-';
+    - replaces any non-numeric and non-alphabetic char into its charCode wrapped by "z";
+  Example: 'a.12#45' => 'a-12z35z45'
+*/
+var getAuthorClassName = function(authorId) {
+  var cleanedAuthorClass = (authorId || '').replace(/[^a-y0-9]/g, function(c) {
+    return c === '.' ? '-': 'z' + c.charCodeAt(0) + 'z';
   });
-}
-var getAuthorClassName = exports.getAuthorClassName;
-
-exports.className2Author = function(className) {
-  if (className.substring(0, 15) == "ep_cursortrace-") {
-    return className.substring(15).replace(/[a-y0-9]+|-|z.+?z/g, function(cc) {
-      if (cc == '-') {
-        return '.';
-      } else if (cc.charAt(0) == 'z') {
-        return String.fromCharCode(Number(cc.slice(1, -1)));
-      } else {
-        return cc;
-      }
-    });
-  }
-  return null;
+  return 'ep_cursortrace-' + cleanedAuthorClass;
 }
 
 exports.buildAndShowIndicators = function(caretLocations) {
@@ -66,7 +57,7 @@ var getAuthorColor = function(author) {
 
 // If the name isn't set then display a smiley face
 var getAuthorName = function(user) {
-  return user.name ? decodeURI(escape(user.name)) : SMILEY;
+  return user.name ? Security.escapeHTMLAttribute(user.name) : SMILEY;
 }
 
 var buildIndicator = function(user, position) {

--- a/static/js/caret_indicator.js
+++ b/static/js/caret_indicator.js
@@ -52,6 +52,8 @@ exports.buildAndShowIndicators = function(caretLocations) {
           fadeOutCaretIndicator($indicator);
         }
       });
+    } else {
+      removeCaretOf(authorId);
     }
   }
 }
@@ -111,10 +113,11 @@ var fadeOutCaretIndicator = function($indicator) {
   }
 }
 
-exports.removeCaretOf = function(userId) {
-  var authorClass = getAuthorClassName(userId);
+exports.removeCaretOf = function(authorId) {
+  var authorClass = getAuthorClassName(authorId);
   var authorClassName = "caret-" + authorClass;
 
   // remove caret indicator on editor
   utils.getOuterDoc().find("." + authorClassName).remove();
 }
+var removeCaretOf = exports.removeCaretOf;

--- a/static/js/caret_location_manager.js
+++ b/static/js/caret_location_manager.js
@@ -39,7 +39,6 @@ exports.updateCaretLocation = function(authorId, line, column) {
 exports.updatePendingCaretLocation = function(authorId, line, column) {
   var caretLocation = buildCaretLocationData(authorId, line, column);
   pendingCaretLocations[authorId] = caretLocation;
-  return caretLocation;
 }
 
 exports.removeCaretLocationOf = function(authorId) {

--- a/static/js/caret_location_manager.js
+++ b/static/js/caret_location_manager.js
@@ -1,0 +1,56 @@
+var currentCaretLocations = {};
+var pendingCaretLocations = {};
+
+exports.activatePendingCaretLocations = function() {
+  currentCaretLocations = pendingCaretLocations;
+  pendingCaretLocations = {};
+}
+
+exports.getCaretLocations = function() {
+  return Object.values(currentCaretLocations);
+}
+var getCaretLocations = exports.getCaretLocations;
+
+exports.getMyCurrentCaretLocation = function() {
+  var myAuthorId = pad.getUserId();
+  return currentCaretLocations[myAuthorId];
+}
+var getMyCurrentCaretLocation = exports.getMyCurrentCaretLocation;
+
+exports.getCaretLocationsAfterLine = function(lineNumber) {
+  var allCaretLocations = getCaretLocations();
+  var caretLocationsAfterTargetLine = allCaretLocations.filter(function(caretLocation) {
+    return caretLocation.line > lineNumber;
+  });
+  return caretLocationsAfterTargetLine;
+}
+
+exports.myPositionChanged = function(line, column) {
+  var lastPositionOfMyCaret = getMyCurrentCaretLocation();
+  return !lastPositionOfMyCaret || line !== lastPositionOfMyCaret.line || column !== lastPositionOfMyCaret.column;
+}
+
+exports.updateCaretLocation = function(authorId, line, column) {
+  var caretLocation = buildCaretLocationData(authorId, line, column);
+  currentCaretLocations[authorId] = caretLocation;
+  return caretLocation;
+}
+
+exports.updatePendingCaretLocation = function(authorId, line, column) {
+  var caretLocation = buildCaretLocationData(authorId, line, column);
+  pendingCaretLocations[authorId] = caretLocation;
+  return caretLocation;
+}
+
+exports.removeCaretLocationOf = function(authorId) {
+  delete currentCaretLocations[authorId];
+}
+
+exports.buildCaretLocationData = function(authorId, line, column) {
+  return {
+    authorId: authorId,
+    line: line,
+    column: column,
+  };
+}
+var buildCaretLocationData = exports.buildCaretLocationData;

--- a/static/js/caret_position.js
+++ b/static/js/caret_position.js
@@ -146,6 +146,8 @@ var copyStyles = function(fromNode, toNode) {
     fontWeight:computedCSS.fontWeight,
     fontFamily:computedCSS.fontFamily,
     lineHeight:computedCSS.lineHeight,
+    display:computedCSS.display,
+    visibility:computedCSS.visibility,
   });
 }
 

--- a/static/js/caret_position.js
+++ b/static/js/caret_position.js
@@ -18,7 +18,7 @@ var utils = require('./utils');
 */
 exports.getCaretPosition = function(caretLine, caretColumn) {
   // Are we ready to get caret position?
-  var $caretDiv = utils.getPadInner().find('#innerdocbody > div:nth-child(' + caretLine + ')');
+  var $caretDiv = utils.getLineOnEditor(caretLine);
   if ($caretDiv.length === 0) return;
 
   // Step 1:

--- a/static/js/css.js
+++ b/static/js/css.js
@@ -1,11 +1,6 @@
-exports.aceEditorCSS = function(hook_name, cb){
+exports.aceEditorCSS = function(hook_name, cb) {
   return [
     "/ep_cursortrace/static/css/cursortrace.css",
     "/ep_cursortrace/static/css/inner_elements_position.css",
   ]; // inner pad CSS
 }
-
-exports.aceInitInnerdocbodyHead = function(hook_name, args, cb) {
-  args.iframeHTML.push('<link rel="stylesheet" type="text/css" href="../static/plugins/ep_cursortrace/static/css/ace_inner.css"/>');
-  return cb();
-};

--- a/static/js/hidden_lines.js
+++ b/static/js/hidden_lines.js
@@ -1,60 +1,108 @@
-// This code was adapted from ep_comments/static/js/textMarkIconsPosition.js
+// This code was initially adapted from ep_comments/static/js/textMarkIconsPosition.js,
+// but had been modified a lot since its creation.
 var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 var utils = require('./utils');
 
 exports.getVisiblePosition = function(line, column) {
-  var caretPosition = buildCaretPosition(line, column);
+  var caretPosition = buildCaretPositionData(line, column);
 
   var $baseLine = utils.getLineOnEditor(line);
   var baseLineNotVisible = !lineIsVisible($baseLine.get(0));
   if (baseLineNotVisible) {
-    caretPosition = getPositionOnClosestVisibleLine($baseLine);
+    caretPosition = getPositionOfClosestVisibleLine($baseLine);
   }
 
   return caretPosition;
+}
+
+var buildCaretPositionData = function(line, column) {
+  return {
+    line: line,
+    column: column,
+  }
 }
 
 var lineIsVisible = function(line) {
   return line.getBoundingClientRect().height > 0;
 }
 
-// when we have a caret in a line that is not visible we have 2 possibilities:
-// [1] the caret is on a hidden SM, so we use the beginning of next visible line
-// [2] the caret is on a hidden SE, so we use the end of previous visible line
-var getPositionOnClosestVisibleLine = function($baseLine) {
-  var searchForward = $baseLine.hasClass('sceneMark');
-  var getVisibleLine = searchForward ? getNextVisibleLine : getPreviousVisibleLine; // [1] / [2]
-  var visibleLine = getVisibleLine($baseLine);
-  var lineNumber = $(visibleLine).index();
-  var columnNumber = searchForward ? 0 : $(visibleLine).text().length - 1; // [1] / [2]
-  return buildCaretPosition(lineNumber, columnNumber);
+var getPositionOfClosestVisibleLine = function($hiddenLine) {
+  var visibleLineInfo = findClosestVisibleLineAndDirectionOfSearch($hiddenLine);
+  var $visibleLine = $(visibleLineInfo.line);
+  var searchedForward = visibleLineInfo.searchedForward;
+
+  var lineNumber = $visibleLine.index();
+  var columnNumber = searchedForward ? 0 : $visibleLine.text().length;
+  return buildCaretPositionData(lineNumber, columnNumber);
 }
 
-var getNextVisibleLine = function($sceneMarkNotVisible) {
-  var $nextSceneMarks = $sceneMarkNotVisible.nextUntil('div:has(heading)').andSelf();
-  var $heading = $nextSceneMarks.last().next();
-  var $nextSceneMarksWithHeading = $nextSceneMarks.add($heading);
-  return getFirstVisibleLineOfSet($nextSceneMarksWithHeading);
+/* when we have a caret in a line that is not visible we have some possibilities:
+   [1] the caret is on a hidden SM:
+      [1.a] there is a visible SM on the same block above caret line: use the end of previous visible line
+      [1.b] there is NO visible SM on the same block above caret line: use the beginning of next visible line
+   [2] the caret is on a hidden SE:
+      [2.a] SE is before 1st scene of script: use the beginning of next visible line
+      [2.b] SE belongs to a scene: use the end of previous visible line
+*/
+var findClosestVisibleLineAndDirectionOfSearch = function($hiddenLine) {
+  var closestVisibleLine;
+  var searchedForward = false;
+
+  var hiddenLineIsASceneMark = $hiddenLine.hasClass('sceneMark');
+  if (hiddenLineIsASceneMark) { // [1]
+    closestVisibleLine = getClosestVisibleSMAbove($hiddenLine); // [1.a]
+    if (!closestVisibleLine) { // [1.b]
+      closestVisibleLine = getClosestVisibleSMOrHeadingBelow($hiddenLine);
+      searchedForward = true;
+    }
+  } else { // [2]
+    if (lineIsBeforeFirstScene($hiddenLine)) { // [2.a]
+      closestVisibleLine = getClosestVisibleLineBelow($hiddenLine);
+      searchedForward = true;
+    } else { // [2.b]
+      closestVisibleLine = getClosestVisibleLineAbove($hiddenLine);
+    }
+  }
+
+  return {
+    line: closestVisibleLine,
+    searchedForward: searchedForward,
+  }
 }
 
-// If we are on a SE and it is hidden, the previous visible line must be a SM.
-// So we [1] go back to the heading; then [2] get the set of SMs of that heading
-var getPreviousVisibleLine = function($scriptElementNotVisible) {
-  var $heading = $scriptElementNotVisible.prevUntil('div:has(heading)').andSelf().first(); // [1]
-  var $previousSceneMarks = $heading.prevUntil('div:not(.sceneMark)'); // [2]
-  return getLastVisibleLineOfSet($previousSceneMarks);
+var getClosestVisibleSMAbove = function($baseLine) {
+  var $sceneMarksAboveBaseLine = $baseLine.prevUntil(':not(.sceneMark)');
+  // $sceneMarksAboveBaseLine are on reversed order
+  return getFirstVisibleLineOfSet($sceneMarksAboveBaseLine);
+}
+
+var getClosestVisibleSMOrHeadingBelow = function($baseLine) {
+  var $sceneMarksBelowBaseLine = $baseLine.nextUntil(':not(.sceneMark, .withHeading)');
+  return getFirstVisibleLineOfSet($sceneMarksBelowBaseLine);
+}
+
+var getClosestVisibleLineAbove = function($baseLine) {
+  var $linesAbove = $baseLine.prevAll();
+  // $linesAbove are on reversed order
+  return getFirstVisibleLineOfSet($linesAbove);
+}
+
+var getClosestVisibleLineBelow = function($baseLine) {
+  var $linesBelow = $baseLine.nextAll();
+  return getFirstVisibleLineOfSet($linesBelow);
+}
+
+var lineIsBeforeFirstScene = function($line) {
+  var lineNumberOfFirstScene = getLineNumberOfFirstScene();
+  var lineNumberOfBaseLine = $line.index();
+  return lineNumberOfBaseLine <= lineNumberOfFirstScene;
+}
+
+var getLineNumberOfFirstScene = function() {
+  var $beginningOfFirstScene = utils.getPadInner().find('div.sceneMark').first();
+  return $beginningOfFirstScene.index();
 }
 
 var getFirstVisibleLineOfSet = function($lines) {
   return $lines.get().find(lineIsVisible);
-}
-var getLastVisibleLineOfSet = function($lines) {
-  return $lines.get().reverse().find(lineIsVisible);
-}
-
-var buildCaretPosition = function(line, column) {
-  return {
-    line: line,
-    column: column,
-  }
 }

--- a/static/js/hidden_lines.js
+++ b/static/js/hidden_lines.js
@@ -1,0 +1,60 @@
+// This code was adapted from ep_comments/static/js/textMarkIconsPosition.js
+var $ = require('ep_etherpad-lite/static/js/rjquery').$;
+var utils = require('./utils');
+
+exports.getVisiblePosition = function(line, column) {
+  var caretPosition = buildCaretPosition(line, column);
+
+  var $baseLine = utils.getLineOnEditor(line);
+  var baseLineNotVisible = !lineIsVisible($baseLine.get(0));
+  if (baseLineNotVisible) {
+    caretPosition = getPositionOnClosestVisibleLine($baseLine);
+  }
+
+  return caretPosition;
+}
+
+var lineIsVisible = function(line) {
+  return line.getBoundingClientRect().height > 0;
+}
+
+// when we have a caret in a line that is not visible we have 2 possibilities:
+// [1] the caret is on a hidden SM, so we use the beginning of next visible line
+// [2] the caret is on a hidden SE, so we use the end of previous visible line
+var getPositionOnClosestVisibleLine = function($baseLine) {
+  var searchForward = $baseLine.hasClass('sceneMark');
+  var getVisibleLine = searchForward ? getNextVisibleLine : getPreviousVisibleLine; // [1] / [2]
+  var visibleLine = getVisibleLine($baseLine);
+  var lineNumber = $(visibleLine).index();
+  var columnNumber = searchForward ? 0 : $(visibleLine).text().length - 1; // [1] / [2]
+  return buildCaretPosition(lineNumber, columnNumber);
+}
+
+var getNextVisibleLine = function($sceneMarkNotVisible) {
+  var $nextSceneMarks = $sceneMarkNotVisible.nextUntil('div:has(heading)').andSelf();
+  var $heading = $nextSceneMarks.last().next();
+  var $nextSceneMarksWithHeading = $nextSceneMarks.add($heading);
+  return getFirstVisibleLineOfSet($nextSceneMarksWithHeading);
+}
+
+// If we are on a SE and it is hidden, the previous visible line must be a SM.
+// So we [1] go back to the heading; then [2] get the set of SMs of that heading
+var getPreviousVisibleLine = function($scriptElementNotVisible) {
+  var $heading = $scriptElementNotVisible.prevUntil('div:has(heading)').andSelf().first(); // [1]
+  var $previousSceneMarks = $heading.prevUntil('div:not(.sceneMark)'); // [2]
+  return getLastVisibleLineOfSet($previousSceneMarks);
+}
+
+var getFirstVisibleLineOfSet = function($lines) {
+  return $lines.get().find(lineIsVisible);
+}
+var getLastVisibleLineOfSet = function($lines) {
+  return $lines.get().reverse().find(lineIsVisible);
+}
+
+var buildCaretPosition = function(line, column) {
+  return {
+    line: line,
+    column: column,
+  }
+}

--- a/static/js/hide_carets_on_disabled_editor.js
+++ b/static/js/hide_carets_on_disabled_editor.js
@@ -1,0 +1,12 @@
+var eascUtils = require('ep_script_toggle_view/static/js/utils');
+var utils = require('./utils');
+
+var DISABLED_CONTAINER_CLASS = 'disabled';
+
+exports.initialize = function() {
+  var $caretIndicatorContainer = utils.getPadOuter().find('#outerdocbody');
+  utils.getPadInner().on(eascUtils.EASC_CHANGED_EVENT, function() {
+    var editorIsDisabled = !eascUtils.isEditorEditable();
+    $caretIndicatorContainer.toggleClass(DISABLED_CONTAINER_CLASS, editorIsDisabled);
+  });
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,14 +1,10 @@
-var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 var LINE_CHANGED_EVENT = require('ep_comments_page/static/js/utils').LINE_CHANGED_EVENT;
 var utils = require('./utils');
-var caretPosition = require('./caret_position');
+var caretIndicator = require('./caret_indicator');
+var caretLocationManager = require('./caret_location_manager');
 
-var SMILEY = "&#9785;"
 var TIME_TO_UPDATE_CARETS_POSITION = 500;
-var INDICATOR_HEIGHT = 16;
 var initiated = false;
-var currentCaretLocations = {};
-var pendingCaretLocations = {};
 
 exports.postAceInit = function(hook_name, args, cb) {
   initiated = true;
@@ -22,8 +18,14 @@ exports.postAceInit = function(hook_name, args, cb) {
 };
 
 var showCaretOfAuthorsAlreadyOnPad = function() {
-  var caretLocations = Object.values(pendingCaretLocations);
-  buildAndShowIndicatorFor(caretLocations);
+  caretLocationManager.activatePendingCaretLocations();
+  var caretLocations = caretLocationManager.getCaretLocations();
+  caretIndicator.buildAndShowIndicators(caretLocations);
+}
+
+var buildAndShowIndicatorsAfterLine = function(lineNumber) {
+  var caretLocations = caretLocationManager.getCaretLocationsAfterLine(lineNumber);
+  caretIndicator.buildAndShowIndicators(caretLocations);
 }
 
 var updateCaretsWhenAnUpdateMightHadAffectedTheirPositions = function() {
@@ -35,44 +37,6 @@ var updateCaretsWhenAnUpdateMightHadAffectedTheirPositions = function() {
   });
 }
 
-var buildAndShowIndicatorsAfterLine = function(lineNumber) {
-  var allCaretLocations = Object.values(currentCaretLocations);
-  var caretLocationsAfterTargetLine = allCaretLocations.filter(function(caretLocation) {
-    return caretLocation.line >= lineNumber;
-  });
-  buildAndShowIndicatorFor(caretLocationsAfterTargetLine);
-}
-
-exports.getAuthorClassName = function(author)
-{
-  if(!author) return;
-  return "ep_cursortrace-" + author.replace(/[^a-y0-9]/g, function(c)
-  {
-    if (c == ".") return "-";
-    return 'z' + c.charCodeAt(0) + 'z';
-  });
-}
-
-exports.className2Author = function(className)
-{
-  if (className.substring(0, 15) == "ep_cursortrace-")
-  {
-    return className.substring(15).replace(/[a-y0-9]+|-|z.+?z/g, function(cc)
-    {
-      if (cc == '-') return '.';
-      else if (cc.charAt(0) == 'z')
-      {
-        return String.fromCharCode(Number(cc.slice(1, -1)));
-      }
-      else
-      {
-        return cc;
-      }
-    });
-  }
-  return null;
-}
-
 exports.aceEditEvent = function(hook_name, args, cb) {
   if (!initiated) return;
 
@@ -81,7 +45,7 @@ exports.aceEditEvent = function(hook_name, args, cb) {
     var line = rep.selStart[0];
     // line might be a line with line attributes, so we need to ignore the '*' on the text
     var column = rep.selStart[1] - rep.lines.atIndex(line).lineMarker;
-    if (positionChanged(line, column)) {
+    if (caretLocationManager.myPositionChanged(line, column)) {
       sendMessageWithCaretPosition(line, column);
     }
   }
@@ -93,12 +57,6 @@ var isCaretMoving = function(args) {
   return (callstack.editEvent.eventType == "handleClick") ||
          (callstack.type === "handleKeyEvent") ||
          (callstack.type === "idleWorkTimer");
-}
-
-var positionChanged = function(line, column) {
-  var myAuthorId = pad.getUserId();
-  var lastPositionOfMyCaret = currentCaretLocations[myAuthorId];
-  return !lastPositionOfMyCaret || line !== lastPositionOfMyCaret.line || column !== lastPositionOfMyCaret.column;
 }
 
 var sendMessageWithCaretPosition = function(line, column) {
@@ -117,28 +75,23 @@ var sendMessageWithCaretPosition = function(line, column) {
   // Send the cursor position message to the server
   pad.collabClient.sendMessage(message);
   // Update set of caretLocations
-  currentCaretLocations[myAuthorId] = buildCaretLocationData(myAuthorId, line, column);
+  caretLocationManager.updateCaretLocation(myAuthorId, line, column);
 }
 
+// we need to send our position to user who joined the pad, so our caret indicator is created there
 exports.handleClientMessage_USER_NEWINFO = function(hook, context, cb) {
-  var myAuthorId = pad.getUserId();
-  var lastPositionOfMyCaret = currentCaretLocations[myAuthorId];
-
+  var lastPositionOfMyCaret = caretLocationManager.getMyCurrentCaretLocation();
   if (lastPositionOfMyCaret) {
-    // we need to send our position to user who joined the pad, so our caret indicator is created there
-    sendMessageWithCaretPosition(lastPositionOfMyCaret[0], lastPositionOfMyCaret[1]);
+    sendMessageWithCaretPosition(lastPositionOfMyCaret.line, lastPositionOfMyCaret.column);
   }
 }
 
 exports.handleClientMessage_USER_LEAVE = function(hook, context, cb) {
   var userId = context.payload.userId;
-  var authorClass = exports.getAuthorClassName(userId);
-  var authorClassName = "caret-" + authorClass;
-
   // remove caret indicator on editor
-  utils.getOuterDoc().find("." + authorClassName).remove();
+  caretIndicator.removeCaretOf(userId);
   // update set of caretLocations
-  delete currentCaretLocations[userId];
+  caretLocationManager.removeCaretLocationOf(userId);
 }
 
 // A huge problem with this is that it runs BEFORE the dom has been updated so edit events are always late..
@@ -153,101 +106,11 @@ exports.handleClientMessage_CUSTOM = function(hook, context, cb) {
   if (pad.getUserId() === authorId) return false;
 
   // an author has sent this client a cursor position, we need to show it in the dom
-  var caretLocationData = buildCaretLocationData(authorId, line, column);
   if (!initiated) {
     // we are not ready yet to show caret indicator, so store it for when we are
-    pendingCaretLocations[authorId] = caretLocationData;
+    caretLocationManager.updatePendingCaretLocation(authorId, line, column);
   } else {
-    buildAndShowIndicatorFor([caretLocationData]);
-  }
-}
-
-var buildCaretLocationData = function(authorId, line, column) {
-  return {
-    authorId: authorId,
-    line: line,
-    column: column,
-  };
-}
-
-var buildAndShowIndicatorFor = function(caretLocations) {
-  var users = pad.collabClient.getConnectedUsers();
-
-  for (var i = 0; i < caretLocations.length; i++) {
-    var caretLocation = caretLocations[i];
-    var authorId = caretLocation.authorId;
-    var line     = caretLocation.line + 1; // +1 as Etherpad line numbers start at 1
-    var column   = caretLocation.column;
-
-    currentCaretLocations[authorId] = caretLocation;
-
-    // Don't show our own caret
-    if (pad.getUserId() === authorId) continue;
-
-    var position = caretPosition.getCaretPosition(line, column);
-    if (position) {
-      $.each(users, function(index, user) {
-        if (user.userId === authorId) {
-          var $indicator = buildIndicator(user, position);
-          showIndicator($indicator, authorId);
-          fadeOutCaretIndicator($indicator);
-        }
-      });
-    }
-  }
-}
-
-var getAuthorColor = function(author) {
-  var colors = pad.getColorPalette(); // support non set colors
-  var color = colors[author.colorId] || author.colorId; // Test for XSS
-  return color;
-}
-
-// If the name isn't set then display a smiley face
-var getAuthorName = function(user) {
-  return user.name ? decodeURI(escape(user.name)) : SMILEY;
-}
-
-var buildIndicator = function(user, position) {
-  // Location of stick direction IE up or down
-  var location = position.top >= INDICATOR_HEIGHT ? 'stickUp' : 'stickDown';
-  var color = getAuthorColor(user);
-  var authorName = getAuthorName(user);
-  var classes = "class='caretindicator " + location + "'";
-  var timestamp = Date.now();
-
-  // Create a new Div for this author
-  var $indicator = $("<div " + classes + " timestamp="+timestamp+"><p>"+authorName+"</p></div>");
-  $indicator.css({
-    height:  INDICATOR_HEIGHT + "px",
-    left: position.left + "px",
-    top: position.top + "px",
-    "background-color": color,
-  });
-
-  return $indicator;
-}
-
-var showIndicator = function($indicator, authorId) {
-  var $outerdoc = utils.getOuterDoc();
-
-  var authorClass = exports.getAuthorClassName(authorId);
-  var authorClassName = "caret-" + authorClass;
-
-  // Remove all divs that already exist for this author
-  $outerdoc.find("." + authorClassName).remove();
-
-  $indicator.addClass(authorClassName);
-  $outerdoc.append($indicator);
-}
-
-var fadeOutCaretIndicator = function($indicator) {
-  if (clientVars.ep_cursortrace.fade_out_timeout) {
-    // After a while, fade it out :)
-    setTimeout(function(){
-      $indicator.fadeOut(500, function(){
-        $indicator.remove();
-      });
-    }, clientVars.ep_cursortrace.fade_out_timeout);
+    var caretLocation = caretLocationManager.updateCaretLocation(authorId, line, column);
+    caretIndicator.buildAndShowIndicators([caretLocation]);
   }
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -2,6 +2,7 @@ var LINE_CHANGED_EVENT = require('ep_comments_page/static/js/utils').LINE_CHANGE
 var utils = require('./utils');
 var caretIndicator = require('./caret_indicator');
 var caretLocationManager = require('./caret_location_manager');
+var hideCaretsOnDisabledEditor = require('./hide_carets_on_disabled_editor');
 
 var TIME_TO_UPDATE_CARETS_POSITION = 500;
 var initiated = false;
@@ -13,6 +14,7 @@ exports.postAceInit = function(hook_name, args, cb) {
   pad.plugins.ep_cursortrace = pad.plugins.ep_cursortrace || {};
   pad.plugins.ep_cursortrace.timeToUpdateCaretPosition = TIME_TO_UPDATE_CARETS_POSITION;
 
+  hideCaretsOnDisabledEditor.initialize();
   showCaretOfAuthorsAlreadyOnPad();
   updateCaretsWhenAnUpdateMightHadAffectedTheirPositions();
 };

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -20,3 +20,9 @@ exports.getOuterDoc = function() {
   $outerDocBody = $outerDocBody || exports.getPadOuter().find("#outerdocbody");
   return $outerDocBody;
 }
+
+exports.getLineOnEditor = function(lineNumber) {
+  // +1 as Etherpad line numbers start at 0
+  var nthChild = lineNumber + 1;
+  return exports.getPadInner().find('#innerdocbody > div:nth-child(' + nthChild + ')');
+}

--- a/static/tests/frontend/specs/_utils.js
+++ b/static/tests/frontend/specs/_utils.js
@@ -64,6 +64,12 @@ ep_cursortrace_test_helper.utils = {
     return { top: top, left: left };
   },
 
+  getDistanceBetweenCaretIndicatorAndBeginningOfLine: function(lineNumber) {
+    var utils = ep_cursortrace_test_helper.utils;
+    var $beginningOfLine = utils.getLine(lineNumber).find('span').first();
+    return utils.getDistanceBetweenCaretIndicatorAndTarget($beginningOfLine, false);
+  },
+
   getDistanceBetweenCaretIndicatorAndEndOfLine: function(lineNumber) {
     var utils = ep_cursortrace_test_helper.utils;
     var $endOfLine = utils.getLine(lineNumber).find('span').last();
@@ -94,5 +100,13 @@ ep_cursortrace_test_helper.utils = {
     helper.waitFor(function() {
       return utils.getCaretIndicator().is(':visible');
     }, 1900).done(done);
+  },
+
+  waitForCaretIndicatorToBeVisibleForBothUsers: function(done) {
+    var utils = ep_cursortrace_test_helper.utils;
+    var multipleUsers = ep_script_copy_cut_paste_test_helper.multipleUsers;
+    utils.waitForCaretIndicatorToBeVisible(function() {
+      multipleUsers.performAsOtherUser(utils.waitForCaretIndicatorToBeVisible, done);
+    });
   },
 }

--- a/static/tests/frontend/specs/_utils.js
+++ b/static/tests/frontend/specs/_utils.js
@@ -102,6 +102,13 @@ ep_cursortrace_test_helper.utils = {
     }, 1900).done(done);
   },
 
+  waitForCaretIndicatorToBeHidden: function(done) {
+    var utils = ep_cursortrace_test_helper.utils;
+    helper.waitFor(function() {
+      return !utils.getCaretIndicator().is(':visible');
+    }, 1900).done(done);
+  },
+
   waitForCaretIndicatorToBeVisibleForBothUsers: function(done) {
     var utils = ep_cursortrace_test_helper.utils;
     var multipleUsers = ep_script_copy_cut_paste_test_helper.multipleUsers;

--- a/static/tests/frontend/specs/_utils.js
+++ b/static/tests/frontend/specs/_utils.js
@@ -66,7 +66,7 @@ ep_cursortrace_test_helper.utils = {
 
   getDistanceBetweenCaretIndicatorAndBeginningOfLine: function(lineNumber) {
     var utils = ep_cursortrace_test_helper.utils;
-    var $beginningOfLine = utils.getLine(lineNumber).find('span').first();
+    var $beginningOfLine = utils.getLine(lineNumber).find('span:not(:empty)').first();
     return utils.getDistanceBetweenCaretIndicatorAndTarget($beginningOfLine, false);
   },
 
@@ -80,18 +80,18 @@ ep_cursortrace_test_helper.utils = {
     return ep_cursortrace_test_helper.utils.getCaretIndicator().position();
   },
 
-  waitForCaretIndicatorToMove: function(originalPosition, done) {
+  waitForCaretIndicatorToMove: function(originalPosition, done, timeout) {
     helper.waitFor(function() {
       var position = ep_cursortrace_test_helper.utils.getCaretIndicatorPosition();
       return position.left !== originalPosition.left || position.top !== originalPosition.top;
-    }).done(done).fail(done);
+    }, timeout || 1000).done(done);
   },
 
-  executeAndWaitForCaretIndicatorToMove: function(execFunction, done) {
+  executeAndWaitForCaretIndicatorToMove: function(execFunction, done, timeout) {
     var utils = ep_cursortrace_test_helper.utils;
     var originalPosition = utils.getCaretIndicatorPosition();
     execFunction(function() {
-      utils.waitForCaretIndicatorToMove(originalPosition, done);
+      utils.waitForCaretIndicatorToMove(originalPosition, done, timeout);
     });
   },
 
@@ -108,5 +108,24 @@ ep_cursortrace_test_helper.utils = {
     utils.waitForCaretIndicatorToBeVisible(function() {
       multipleUsers.performAsOtherUser(utils.waitForCaretIndicatorToBeVisible, done);
     });
+  },
+
+  placeCaretOfOtherUserAtBeginningOfLine: function(lineNumber, done) {
+    ep_cursortrace_test_helper.utils._placeCaretOfOtherUserAtLine(lineNumber, false, done);
+  },
+  placeCaretOfOtherUserAtEndOfLine: function(lineNumber, done) {
+    ep_cursortrace_test_helper.utils._placeCaretOfOtherUserAtLine(lineNumber, true, done);
+  },
+  _placeCaretOfOtherUserAtLine: function(lineNumber, atEndOfLine, done) {
+    var utils = ep_cursortrace_test_helper.utils;
+    var multipleUsers = ep_script_copy_cut_paste_test_helper.multipleUsers;
+
+    multipleUsers.startActingLikeOtherUser();
+    var $line = utils.getLine(lineNumber);
+    var command = atEndOfLine ? '{selectall}{rightarrow}' : '{selectall}{leftarrow}';
+    $line.sendkeys(command);
+
+    multipleUsers.startActingLikeThisUser();
+    done();
   },
 }

--- a/static/tests/frontend/specs/_utils.js
+++ b/static/tests/frontend/specs/_utils.js
@@ -12,7 +12,6 @@ ep_cursortrace_test_helper.utils = {
     helper.newPad(function() {
       createScript(function() {
         var utils = ep_cursortrace_test_helper.utils;
-
         utils.speedUpCaretUpdate();
 
         // force setting to not hide caret indicators after some time, so tests
@@ -65,19 +64,17 @@ ep_cursortrace_test_helper.utils = {
   },
 
   getDistanceBetweenCaretIndicatorAndBeginningOfLine: function(lineNumber) {
-    var utils = ep_cursortrace_test_helper.utils;
-    var $beginningOfLine = utils.getLine(lineNumber).find('span:not(:empty)').first();
-    return utils.getDistanceBetweenCaretIndicatorAndTarget($beginningOfLine, false);
+    var $beginningOfLine = this.getLine(lineNumber).find('span:not(:empty)').first();
+    return this.getDistanceBetweenCaretIndicatorAndTarget($beginningOfLine, false);
   },
 
   getDistanceBetweenCaretIndicatorAndEndOfLine: function(lineNumber) {
-    var utils = ep_cursortrace_test_helper.utils;
-    var $endOfLine = utils.getLine(lineNumber).find('span').last();
-    return utils.getDistanceBetweenCaretIndicatorAndTarget($endOfLine, true);
+    var $endOfLine = this.getLine(lineNumber).find('span').last();
+    return this.getDistanceBetweenCaretIndicatorAndTarget($endOfLine, true);
   },
 
   getCaretIndicatorPosition: function() {
-    return ep_cursortrace_test_helper.utils.getCaretIndicator().position();
+    return this.getCaretIndicator().position();
   },
 
   waitForCaretIndicatorToMove: function(originalPosition, done, timeout) {
@@ -118,17 +115,16 @@ ep_cursortrace_test_helper.utils = {
   },
 
   placeCaretOfOtherUserAtBeginningOfLine: function(lineNumber, done) {
-    ep_cursortrace_test_helper.utils._placeCaretOfOtherUserAtLine(lineNumber, false, done);
+    this._placeCaretOfOtherUserAtLine(lineNumber, false, done);
   },
   placeCaretOfOtherUserAtEndOfLine: function(lineNumber, done) {
-    ep_cursortrace_test_helper.utils._placeCaretOfOtherUserAtLine(lineNumber, true, done);
+    this._placeCaretOfOtherUserAtLine(lineNumber, true, done);
   },
   _placeCaretOfOtherUserAtLine: function(lineNumber, atEndOfLine, done) {
-    var utils = ep_cursortrace_test_helper.utils;
     var multipleUsers = ep_script_copy_cut_paste_test_helper.multipleUsers;
 
     multipleUsers.startActingLikeOtherUser();
-    var $line = utils.getLine(lineNumber);
+    var $line = this.getLine(lineNumber);
     var command = atEndOfLine ? '{selectall}{rightarrow}' : '{selectall}{leftarrow}';
     $line.sendkeys(command);
 

--- a/static/tests/frontend/specs/integration-ep_sm.js
+++ b/static/tests/frontend/specs/integration-ep_sm.js
@@ -38,67 +38,23 @@ describe('ep_cursortrace - integration with ep_script_scene_marks', function () 
     smUtils = ep_script_scene_marks_test_helper.utils;
 
     utils.openPadForMultipleUsers(this, createScript, function() {
-      // wait for both caret indicators to be shown
-      utils.waitForCaretIndicatorToBeVisible(function() {
-        multipleUsers.performAsOtherUser(utils.waitForCaretIndicatorToBeVisible, done);
-      });
+      utils.waitForCaretIndicatorToBeVisibleForBothUsers(done);
     });
   });
 
   context('when other user places caret on a SM hidden for this user', function() {
-    it('shows caret indicator on beginning of line with heading');
-  });
-
-  context('when other user places caret on a line before a SM hidden for this user', function() {
     var moveCaret = function(done) {
       multipleUsers.startActingLikeOtherUser();
-      var $line = utils.getLine(LINE_BEFORE_SM);
+      var $line = utils.getLine(LINE_WITH_HEADING - 1);
       $line.sendkeys('{selectall}{rightarrow}');
 
       multipleUsers.startActingLikeThisUser();
       done();
     }
 
-    it('updates the caret indicator for this user', function(done) {
+    it('shows caret indicator on beginning of line with heading', function(done) {
       utils.executeAndWaitForCaretIndicatorToMove(moveCaret, function() {
-        var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(LINE_BEFORE_SM);
-        expect(distance.left).to.be(0);
-        expect(distance.top).to.be(0);
-        done();
-      });
-    });
-
-    context('and this user opens the SM', function() {
-      var originalTimestamp;
-
-      before(function() {
-        originalTimestamp = utils.getCaretIndicator().attr('timestamp');
-        if (!originalTimestamp) {
-          utils.failTest('Timestamp not set on caret indicator');
-        }
-
-        smUtils.clickOnSceneMarkButtonOfLine(LINE_WITH_HEADING);
-      });
-
-      after(function() {
-        // close SM again
-        smUtils.clickOnSceneMarkButtonOfLine(LINE_WITH_HEADING);
-      });
-
-      it('does not update the caret indicator', function(done) {
-        helper.waitFor(function() {
-          var timestamp = utils.getCaretIndicator().attr('timestamp');
-          return timestamp !== originalTimestamp;
-        }, 1900).done(function() {
-          utils.failTest('Caret indicator was updated');
-        }).fail(function() {
-          // all set, no indicator was updated call. We can finish the test
-          done();
-        });
-      });
-
-      it('keeps the caret indicator on the right position', function(done) {
-        var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(LINE_BEFORE_SM);
+        var distance = utils.getDistanceBetweenCaretIndicatorAndBeginningOfLine(LINE_WITH_HEADING);
         expect(distance.left).to.be(0);
         expect(distance.top).to.be(0);
         done();
@@ -149,8 +105,65 @@ describe('ep_cursortrace - integration with ep_script_scene_marks', function () 
         }, 1900).done(done);
       });
 
-      it('moves the caret indicator to the right position', function(done) {
+      it('moves the caret indicator to the new position of the caret of the other user', function(done) {
         var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(LINE_AFTER_SM);
+        expect(distance.left).to.be(0);
+        expect(distance.top).to.be(0);
+        done();
+      });
+    });
+  });
+
+  context('when other user places caret on a line before a SM hidden for this user', function() {
+    var moveCaret = function(done) {
+      multipleUsers.startActingLikeOtherUser();
+      var $line = utils.getLine(LINE_BEFORE_SM);
+      $line.sendkeys('{selectall}{rightarrow}');
+
+      multipleUsers.startActingLikeThisUser();
+      done();
+    }
+
+    it('updates the caret indicator for this user', function(done) {
+      utils.executeAndWaitForCaretIndicatorToMove(moveCaret, function() {
+        var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(LINE_BEFORE_SM);
+        expect(distance.left).to.be(0);
+        expect(distance.top).to.be(0);
+        done();
+      });
+    });
+
+    context('and this user opens the SM', function() {
+      var originalTimestamp;
+
+      before(function() {
+        originalTimestamp = utils.getCaretIndicator().attr('timestamp');
+        if (!originalTimestamp) {
+          utils.failTest('Timestamp not set on caret indicator');
+        }
+
+        smUtils.clickOnSceneMarkButtonOfLine(LINE_WITH_HEADING);
+      });
+
+      after(function() {
+        // close SM again
+        smUtils.clickOnSceneMarkButtonOfLine(LINE_WITH_HEADING);
+      });
+
+      it('does not update the caret indicator', function(done) {
+        helper.waitFor(function() {
+          var timestamp = utils.getCaretIndicator().attr('timestamp');
+          return timestamp !== originalTimestamp;
+        }, 1900).done(function() {
+          utils.failTest('Caret indicator was updated');
+        }).fail(function() {
+          // all set, no indicator was updated call. We can finish the test
+          done();
+        });
+      });
+
+      it('keeps the caret indicator close to the caret of the other user', function(done) {
+        var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(LINE_BEFORE_SM);
         expect(distance.left).to.be(0);
         expect(distance.top).to.be(0);
         done();

--- a/static/tests/frontend/specs/integration-ep_sm.js
+++ b/static/tests/frontend/specs/integration-ep_sm.js
@@ -44,12 +44,7 @@ describe('ep_cursortrace - integration with ep_script_scene_marks', function () 
 
   context('when other user places caret on a SM hidden for this user', function() {
     var moveCaret = function(done) {
-      multipleUsers.startActingLikeOtherUser();
-      var $line = utils.getLine(LINE_WITH_HEADING - 1);
-      $line.sendkeys('{selectall}{rightarrow}');
-
-      multipleUsers.startActingLikeThisUser();
-      done();
+      utils.placeCaretOfOtherUserAtEndOfLine(LINE_WITH_HEADING - 1, done);
     }
 
     it('shows caret indicator on beginning of line with heading', function(done) {
@@ -64,12 +59,7 @@ describe('ep_cursortrace - integration with ep_script_scene_marks', function () 
 
   context('when other user places caret on a line after a SM hidden for this user', function() {
     var moveCaret = function(done) {
-      multipleUsers.startActingLikeOtherUser();
-      var $line = utils.getLine(LINE_AFTER_SM);
-      $line.sendkeys('{selectall}{rightarrow}');
-
-      multipleUsers.startActingLikeThisUser();
-      done();
+      utils.placeCaretOfOtherUserAtEndOfLine(LINE_AFTER_SM, done);
     }
 
     it('updates the caret indicator for this user', function(done) {
@@ -116,12 +106,7 @@ describe('ep_cursortrace - integration with ep_script_scene_marks', function () 
 
   context('when other user places caret on a line before a SM hidden for this user', function() {
     var moveCaret = function(done) {
-      multipleUsers.startActingLikeOtherUser();
-      var $line = utils.getLine(LINE_BEFORE_SM);
-      $line.sendkeys('{selectall}{rightarrow}');
-
-      multipleUsers.startActingLikeThisUser();
-      done();
+      utils.placeCaretOfOtherUserAtEndOfLine(LINE_BEFORE_SM, done);
     }
 
     it('updates the caret indicator for this user', function(done) {

--- a/static/tests/frontend/specs/integration-ep_toggle.js
+++ b/static/tests/frontend/specs/integration-ep_toggle.js
@@ -1,119 +1,162 @@
 describe('ep_cursortrace - integration with ep_script_toggle_view', function () {
   var utils, smUtils, eascUtils, multipleUsers;
 
-  var LINE_BEFORE_SEQ             = 0;
-  var LINE_WITH_ACT_TITLE         = LINE_BEFORE_SEQ             + 2;
-  var LINE_WITH_ACT_DESCRIPTION   = LINE_WITH_ACT_TITLE         + 1;
-  var LINE_WITH_SEQ_TITLE         = LINE_WITH_ACT_DESCRIPTION   + 1;
-  var LINE_WITH_SEQ_DESCRIPTION_1 = LINE_WITH_SEQ_TITLE         + 1;
-  var LINE_WITH_SEQ_DESCRIPTION_2 = LINE_WITH_SEQ_DESCRIPTION_1 + 1;
-  var LINE_WITH_SCE_TITLE         = LINE_WITH_SEQ_DESCRIPTION_2 + 1;
-  var LINE_WITH_SCE_DESCRIPTION   = LINE_WITH_SCE_TITLE         + 1;
-  var LINE_WITH_HEADING           = LINE_WITH_SCE_DESCRIPTION   + 1;
-  var LINE_AFTER_HEADING          = LINE_WITH_HEADING           + 3;
-
-  /*
-    Script lines:
-      LINE_BEFORE_SEQ              --\
-      LINE_WITH_ACT_TITLE             +--> group 1
-      LINE_WITH_ACT_DESCRIPTION    --/
-      LINE_WITH_SEQ_TITLE          --\
-      LINE_WITH_SEQ_DESCRIPTION_1     +--> group 2
-      LINE_WITH_SEQ_DESCRIPTION_2  --/
-      LINE_WITH_SCE_TITLE          --\
-      LINE_WITH_SCE_DESCRIPTION       \
-      LINE_WITH_HEADING                +--> group 3
-      some lines...                   /
-      LINE_AFTER_HEADING           --/
-  */
-  var createScript = function(done) {
-    // add a SM, and some content before and after it
-    var sceneText = 'scene 1';
-    var firstLineText = 'first line '.repeat(10);
-    var lastLineText = 'last line '.repeat(10);
-
-    var lineBeforeSM = smUtils.action(firstLineText);
-    var lineAfterSM  = smUtils.action(lastLineText);
-    var act          = smUtils.act(sceneText);
-    // sequence has 2 lines of the description
-    var sequence     = smUtils.sequence(sceneText) + smUtils.sequenceSummary(sceneText);
-    var synopsis     = smUtils.synopsis(sceneText);
-    var heading      = smUtils.heading(sceneText);
-    var separator    = smUtils.general('separator');
-
-    // add a separator between target lines and SM/heading, as lines adjacent to changed
-    // line are also updated
-    var script = lineBeforeSM +
-                 separator +
-                 act +
-                 sequence +
-                 synopsis +
-                 heading +
-                 separator.repeat(3) +
-                 lineAfterSM;
-
-    smUtils.createScriptWith(script, lastLineText, done);
-  }
-
-  var moveCaretOfOtherUserToLine = function(lineNumber) {
-    return function(done) {
-      utils.placeCaretOfOtherUserAtEndOfLine(lineNumber, done);
-    };
-  }
-
-  // function to be used when we have a series of scenarios that should show the
-  // caret at the same place. We need to know when they were moved to the expected
-  // place, so to do that we force them to move somewhere else, and then execute
-  // the action that should move caret indicator to the final position
-  var forceCaretIndicatorToMove = function(done) {
-    var moveCaretToTheMiddleOfSequence = function(done) {
-      utils.placeCaretOfOtherUserAtBeginningOfLine(LINE_WITH_SEQ_DESCRIPTION_1, done);
-    };
-
-    utils.executeAndWaitForCaretIndicatorToMove(moveCaretToTheMiddleOfSequence, done);
-  }
-
-  var testCaretIndicatorIsOnSamePositionOfCaret = function(testConfig) {
-    it('shows caret indicator on the exact position when the other user placed it', function(done) {
-      var moveCaret = moveCaretOfOtherUserToLine(testConfig.lineNumber);
-      utils.executeAndWaitForCaretIndicatorToMove(moveCaret, function() {
-        var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(testConfig.lineNumber);
-        expect(distance.left).to.be(0);
-        expect(distance.top).to.be(0);
-        done();
-      }, 1900);
-    });
-  };
-
-  var testCaretIndicatorIsAtBeginningOfSequenceTitle = function(testConfig) {
-    it('shows caret indicator at the beginning of sequence title', function(done) {
-      var moveCaret = moveCaretOfOtherUserToLine(testConfig.lineNumber);
-      utils.executeAndWaitForCaretIndicatorToMove(moveCaret, function() {
-        var distance = utils.getDistanceBetweenCaretIndicatorAndBeginningOfLine(LINE_WITH_SEQ_TITLE);
-        expect(distance.left).to.be(0);
-        expect(distance.top).to.be(0);
-        done();
-      }, 1900);
-    });
-  };
-
-  var testCaretIndicatorIsAtEndOfSequenceDescription = function(testConfig) {
-    it('shows caret indicator at the end of last line of sequence description', function(done) {
-      var moveCaret = moveCaretOfOtherUserToLine(testConfig.lineNumber);
-      utils.executeAndWaitForCaretIndicatorToMove(moveCaret, function() {
-        var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(LINE_WITH_SEQ_DESCRIPTION_2);
-        expect(distance.left).to.be(0);
-        expect(distance.top).to.be(0);
-        done();
-      }, 1900);
-    });
-  };
-
-  before(function(done) {
+  before(function() {
     multipleUsers = ep_script_copy_cut_paste_test_helper.multipleUsers;
     utils         = ep_cursortrace_test_helper.utils;
     smUtils       = ep_script_scene_marks_test_helper.utils;
     eascUtils     = ep_script_toggle_view_test_helper.utils;
+  });
+
+  context('when script is empty', function() {
+    var createEmptyScript = function(done) {
+      done();
+    }
+
+    before(function(done) {
+      utils.openPadForMultipleUsers(this, createEmptyScript, function() {
+        utils.waitForCaretIndicatorToBeVisibleForBothUsers(done);
+      });
+    });
+
+    context('and all EASC levels are disabled', function() {
+      before(function() {
+        eascUtils.setEascMode([]);
+      });
+
+      after(function(done) {
+        eascUtils.setEascMode(['script']);
+        utils.waitForCaretIndicatorToBeVisible(done);
+      });
+
+      it('hides the caret indicator', function(done) {
+        utils.waitForCaretIndicatorToBeHidden(done);
+      });
+
+      context('and Script level is enabled again', function() {
+        before(function() {
+          eascUtils.setEascMode(['script']);
+        });
+
+        after(function() {
+          eascUtils.setEascMode([]);
+        });
+
+        it('shows the caret indicator again', function(done) {
+          utils.waitForCaretIndicatorToBeVisible(done);
+        });
+      });
+    });
+  });
+
+  context('when script has multiple SM levels', function() {
+    var LINE_BEFORE_SEQ             = 0;
+    var LINE_WITH_ACT_TITLE         = LINE_BEFORE_SEQ             + 2;
+    var LINE_WITH_ACT_DESCRIPTION   = LINE_WITH_ACT_TITLE         + 1;
+    var LINE_WITH_SEQ_TITLE         = LINE_WITH_ACT_DESCRIPTION   + 1;
+    var LINE_WITH_SEQ_DESCRIPTION_1 = LINE_WITH_SEQ_TITLE         + 1;
+    var LINE_WITH_SEQ_DESCRIPTION_2 = LINE_WITH_SEQ_DESCRIPTION_1 + 1;
+    var LINE_WITH_SCE_TITLE         = LINE_WITH_SEQ_DESCRIPTION_2 + 1;
+    var LINE_WITH_SCE_DESCRIPTION   = LINE_WITH_SCE_TITLE         + 1;
+    var LINE_WITH_HEADING           = LINE_WITH_SCE_DESCRIPTION   + 1;
+    var LINE_AFTER_HEADING          = LINE_WITH_HEADING           + 3;
+
+    /*
+      Script lines:
+        LINE_BEFORE_SEQ              --\
+        LINE_WITH_ACT_TITLE             +--> group 1
+        LINE_WITH_ACT_DESCRIPTION    --/
+        LINE_WITH_SEQ_TITLE          --\
+        LINE_WITH_SEQ_DESCRIPTION_1     +--> group 2
+        LINE_WITH_SEQ_DESCRIPTION_2  --/
+        LINE_WITH_SCE_TITLE          --\
+        LINE_WITH_SCE_DESCRIPTION       \
+        LINE_WITH_HEADING                +--> group 3
+        some lines...                   /
+        LINE_AFTER_HEADING           --/
+    */
+    var createScript = function(done) {
+      // add a SM, and some content before and after it
+      var sceneText = 'scene 1';
+      var firstLineText = 'first line '.repeat(10);
+      var lastLineText = 'last line '.repeat(10);
+
+      var lineBeforeSM = smUtils.action(firstLineText);
+      var lineAfterSM  = smUtils.action(lastLineText);
+      var act          = smUtils.act(sceneText);
+      // sequence has 2 lines of the description
+      var sequence     = smUtils.sequence(sceneText) + smUtils.sequenceSummary(sceneText);
+      var synopsis     = smUtils.synopsis(sceneText);
+      var heading      = smUtils.heading(sceneText);
+      var separator    = smUtils.general('separator');
+
+      // add a separator between target lines and SM/heading, as lines adjacent to changed
+      // line are also updated
+      var script = lineBeforeSM +
+                   separator +
+                   act +
+                   sequence +
+                   synopsis +
+                   heading +
+                   separator.repeat(3) +
+                   lineAfterSM;
+
+      smUtils.createScriptWith(script, lastLineText, done);
+    }
+
+    var moveCaretOfOtherUserToLine = function(lineNumber) {
+      return function(done) {
+        utils.placeCaretOfOtherUserAtEndOfLine(lineNumber, done);
+      };
+    }
+
+    // function to be used when we have a series of scenarios that should show the
+    // caret at the same place. We need to know when they were moved to the expected
+    // place, so to do that we force them to move somewhere else, and then execute
+    // the action that should move caret indicator to the final position
+    var forceCaretIndicatorToMove = function(done) {
+      var moveCaretToTheMiddleOfSequence = function(done) {
+        utils.placeCaretOfOtherUserAtBeginningOfLine(LINE_WITH_SEQ_DESCRIPTION_1, done);
+      };
+
+      utils.executeAndWaitForCaretIndicatorToMove(moveCaretToTheMiddleOfSequence, done);
+    }
+
+    var testCaretIndicatorIsOnSamePositionOfCaret = function(testConfig) {
+      it('shows caret indicator on the exact position when the other user placed it', function(done) {
+        var moveCaret = moveCaretOfOtherUserToLine(testConfig.lineNumber);
+        utils.executeAndWaitForCaretIndicatorToMove(moveCaret, function() {
+          var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(testConfig.lineNumber);
+          expect(distance.left).to.be(0);
+          expect(distance.top).to.be(0);
+          done();
+        }, 1900);
+      });
+    }
+
+    var testCaretIndicatorIsAtBeginningOfSequenceTitle = function(testConfig) {
+      it('shows caret indicator at the beginning of sequence title', function(done) {
+        var moveCaret = moveCaretOfOtherUserToLine(testConfig.lineNumber);
+        utils.executeAndWaitForCaretIndicatorToMove(moveCaret, function() {
+          var distance = utils.getDistanceBetweenCaretIndicatorAndBeginningOfLine(LINE_WITH_SEQ_TITLE);
+          expect(distance.left).to.be(0);
+          expect(distance.top).to.be(0);
+          done();
+        }, 1900);
+      });
+    }
+
+    var testCaretIndicatorIsAtEndOfSequenceDescription = function(testConfig) {
+      it('shows caret indicator at the end of last line of sequence description', function(done) {
+        var moveCaret = moveCaretOfOtherUserToLine(testConfig.lineNumber);
+        utils.executeAndWaitForCaretIndicatorToMove(moveCaret, function() {
+          var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(LINE_WITH_SEQ_DESCRIPTION_2);
+          expect(distance.left).to.be(0);
+          expect(distance.top).to.be(0);
+          done();
+        }, 1900);
+      });
+    }
 
     var openSM = function(done) {
       multipleUsers.startActingLikeOtherUser();
@@ -122,58 +165,58 @@ describe('ep_cursortrace - integration with ep_script_toggle_view', function () 
       done();
     }
 
-    utils.openPadForMultipleUsers(this, createScript, function() {
-      utils.waitForCaretIndicatorToBeVisibleForBothUsers(function() {
-        // open SM for the other user, so all lines of the SM are visible
-        utils.executeAndWaitForCaretIndicatorToMove(openSM, done);
-      });
-    });
-  });
-
-  context('when EASC is [SEQ]', function() {
-    before(function() {
-      eascUtils.setEascMode(['sequence']);
-    });
-
-    [
-      // [group 1] tests for caret on lines that are visible
-      { test: testCaretIndicatorIsOnSamePositionOfCaret, lineNumber: LINE_WITH_SEQ_TITLE,         description: 'the sequence title'},
-      { test: testCaretIndicatorIsOnSamePositionOfCaret, lineNumber: LINE_WITH_SEQ_DESCRIPTION_1, description: 'the first line of sequence description'},
-      { test: testCaretIndicatorIsOnSamePositionOfCaret, lineNumber: LINE_WITH_SEQ_DESCRIPTION_2, description: 'the last line of sequence description'},
-      // [group 2] tests for caret on lines that are before first visible line
-      { test: testCaretIndicatorIsAtBeginningOfSequenceTitle, lineNumber: LINE_BEFORE_SEQ,           description: 'a line way before first visible line'},
-      { test: testCaretIndicatorIsAtBeginningOfSequenceTitle, lineNumber: LINE_WITH_ACT_TITLE,       description: 'the act title'},
-      { test: testCaretIndicatorIsAtBeginningOfSequenceTitle, lineNumber: LINE_WITH_ACT_DESCRIPTION, description: 'the act description'},
-      // [group 3] tests for caret on lines that are after last visible line
-      { test: testCaretIndicatorIsAtEndOfSequenceDescription, lineNumber: LINE_WITH_SCE_TITLE,       description: 'the synopsis title'},
-      { test: testCaretIndicatorIsAtEndOfSequenceDescription, lineNumber: LINE_WITH_SCE_DESCRIPTION, description: 'the synopsis description'},
-      { test: testCaretIndicatorIsAtEndOfSequenceDescription, lineNumber: LINE_WITH_HEADING,         description: 'the heading'},
-      { test: testCaretIndicatorIsAtEndOfSequenceDescription, lineNumber: LINE_AFTER_HEADING,        description: 'a line way after last visible line'},
-    ].forEach(function(testConfig) {
-        context('and line is ' + testConfig.description, function() {
-          before(function(done) {
-            forceCaretIndicatorToMove(done);
-          });
-
-          testConfig.test(testConfig);
+    before(function(done) {
+      utils.openPadForMultipleUsers(this, createScript, function() {
+        utils.waitForCaretIndicatorToBeVisibleForBothUsers(function() {
+          // open SM for the other user, so all lines of the SM are visible
+          utils.executeAndWaitForCaretIndicatorToMove(openSM, done);
         });
       });
-  });
-
-  context('when all EASC levels are disabled', function() {
-    before(function() {
-      eascUtils.setEascMode([]);
     });
 
-    after(function(done) {
-      eascUtils.setEascMode(['script']);
-      utils.waitForCaretIndicatorToBeVisible(done);
+    context('and EASC is [SEQ]', function() {
+      before(function() {
+        eascUtils.setEascMode(['sequence']);
+      });
+
+      [
+        // [group 1] tests for caret on lines that are visible
+        { test: testCaretIndicatorIsOnSamePositionOfCaret, lineNumber: LINE_WITH_SEQ_TITLE,         description: 'the sequence title'},
+        { test: testCaretIndicatorIsOnSamePositionOfCaret, lineNumber: LINE_WITH_SEQ_DESCRIPTION_1, description: 'the first line of sequence description'},
+        { test: testCaretIndicatorIsOnSamePositionOfCaret, lineNumber: LINE_WITH_SEQ_DESCRIPTION_2, description: 'the last line of sequence description'},
+        // [group 2] tests for caret on lines that are before first visible line
+        { test: testCaretIndicatorIsAtBeginningOfSequenceTitle, lineNumber: LINE_BEFORE_SEQ,           description: 'a line way before first visible line'},
+        { test: testCaretIndicatorIsAtBeginningOfSequenceTitle, lineNumber: LINE_WITH_ACT_TITLE,       description: 'the act title'},
+        { test: testCaretIndicatorIsAtBeginningOfSequenceTitle, lineNumber: LINE_WITH_ACT_DESCRIPTION, description: 'the act description'},
+        // [group 3] tests for caret on lines that are after last visible line
+        { test: testCaretIndicatorIsAtEndOfSequenceDescription, lineNumber: LINE_WITH_SCE_TITLE,       description: 'the synopsis title'},
+        { test: testCaretIndicatorIsAtEndOfSequenceDescription, lineNumber: LINE_WITH_SCE_DESCRIPTION, description: 'the synopsis description'},
+        { test: testCaretIndicatorIsAtEndOfSequenceDescription, lineNumber: LINE_WITH_HEADING,         description: 'the heading'},
+        { test: testCaretIndicatorIsAtEndOfSequenceDescription, lineNumber: LINE_AFTER_HEADING,        description: 'a line way after last visible line'},
+      ].forEach(function(testConfig) {
+          context('and line is ' + testConfig.description, function() {
+            before(function(done) {
+              forceCaretIndicatorToMove(done);
+            });
+
+            testConfig.test(testConfig);
+          });
+        });
     });
 
-    it('hides the caret indicator', function(done) {
-      helper.waitFor(function() {
-        return !utils.getCaretIndicator().is(':visible');
-      }, 1900).done(done);
+    context('and all EASC levels are disabled', function() {
+      before(function() {
+        eascUtils.setEascMode([]);
+      });
+
+      after(function(done) {
+        eascUtils.setEascMode(['script']);
+        utils.waitForCaretIndicatorToBeVisible(done);
+      });
+
+      it('hides the caret indicator', function(done) {
+        utils.waitForCaretIndicatorToBeHidden(done);
+      });
     });
   });
 });

--- a/static/tests/frontend/specs/integration-ep_toggle.js
+++ b/static/tests/frontend/specs/integration-ep_toggle.js
@@ -1,0 +1,179 @@
+describe('ep_cursortrace - integration with ep_script_toggle_view', function () {
+  var utils, smUtils, eascUtils, multipleUsers;
+
+  var LINE_BEFORE_SEQ             = 0;
+  var LINE_WITH_ACT_TITLE         = LINE_BEFORE_SEQ             + 2;
+  var LINE_WITH_ACT_DESCRIPTION   = LINE_WITH_ACT_TITLE         + 1;
+  var LINE_WITH_SEQ_TITLE         = LINE_WITH_ACT_DESCRIPTION   + 1;
+  var LINE_WITH_SEQ_DESCRIPTION_1 = LINE_WITH_SEQ_TITLE         + 1;
+  var LINE_WITH_SEQ_DESCRIPTION_2 = LINE_WITH_SEQ_DESCRIPTION_1 + 1;
+  var LINE_WITH_SCE_TITLE         = LINE_WITH_SEQ_DESCRIPTION_2 + 1;
+  var LINE_WITH_SCE_DESCRIPTION   = LINE_WITH_SCE_TITLE         + 1;
+  var LINE_WITH_HEADING           = LINE_WITH_SCE_DESCRIPTION   + 1;
+  var LINE_AFTER_HEADING          = LINE_WITH_HEADING           + 3;
+
+  /*
+    Script lines:
+      LINE_BEFORE_SEQ              --\
+      LINE_WITH_ACT_TITLE             +--> group 1
+      LINE_WITH_ACT_DESCRIPTION    --/
+      LINE_WITH_SEQ_TITLE          --\
+      LINE_WITH_SEQ_DESCRIPTION_1     +--> group 2
+      LINE_WITH_SEQ_DESCRIPTION_2  --/
+      LINE_WITH_SCE_TITLE          --\
+      LINE_WITH_SCE_DESCRIPTION       \
+      LINE_WITH_HEADING                +--> group 3
+      some lines...                   /
+      LINE_AFTER_HEADING           --/
+  */
+  var createScript = function(done) {
+    // add a SM, and some content before and after it
+    var sceneText = 'scene 1';
+    var firstLineText = 'first line '.repeat(10);
+    var lastLineText = 'last line '.repeat(10);
+
+    var lineBeforeSM = smUtils.action(firstLineText);
+    var lineAfterSM  = smUtils.action(lastLineText);
+    var act          = smUtils.act(sceneText);
+    // sequence has 2 lines of the description
+    var sequence     = smUtils.sequence(sceneText) + smUtils.sequenceSummary(sceneText);
+    var synopsis     = smUtils.synopsis(sceneText);
+    var heading      = smUtils.heading(sceneText);
+    var separator    = smUtils.general('separator');
+
+    // add a separator between target lines and SM/heading, as lines adjacent to changed
+    // line are also updated
+    var script = lineBeforeSM +
+                 separator +
+                 act +
+                 sequence +
+                 synopsis +
+                 heading +
+                 separator.repeat(3) +
+                 lineAfterSM;
+
+    smUtils.createScriptWith(script, lastLineText, done);
+  }
+
+  var moveCaretOfOtherUserToLine = function(lineNumber) {
+    return function(done) {
+      utils.placeCaretOfOtherUserAtEndOfLine(lineNumber, done);
+    };
+  }
+
+  // function to be used when we have a series of scenarios that should show the
+  // caret at the same place. We need to know when they were moved to the expected
+  // place, so to do that we force them to move somewhere else, and then execute
+  // the action that should move caret indicator to the final position
+  var forceCaretIndicatorToMove = function(done) {
+    var moveCaretToTheMiddleOfSequence = function(done) {
+      utils.placeCaretOfOtherUserAtBeginningOfLine(LINE_WITH_SEQ_DESCRIPTION_1, done);
+    };
+
+    utils.executeAndWaitForCaretIndicatorToMove(moveCaretToTheMiddleOfSequence, done);
+  }
+
+  var testCaretIndicatorIsOnSamePositionOfCaret = function(testConfig) {
+    it('shows caret indicator on the exact position when the other user placed it', function(done) {
+      var moveCaret = moveCaretOfOtherUserToLine(testConfig.lineNumber);
+      utils.executeAndWaitForCaretIndicatorToMove(moveCaret, function() {
+        var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(testConfig.lineNumber);
+        expect(distance.left).to.be(0);
+        expect(distance.top).to.be(0);
+        done();
+      }, 1900);
+    });
+  };
+
+  var testCaretIndicatorIsAtBeginningOfSequenceTitle = function(testConfig) {
+    it('shows caret indicator at the beginning of sequence title', function(done) {
+      var moveCaret = moveCaretOfOtherUserToLine(testConfig.lineNumber);
+      utils.executeAndWaitForCaretIndicatorToMove(moveCaret, function() {
+        var distance = utils.getDistanceBetweenCaretIndicatorAndBeginningOfLine(LINE_WITH_SEQ_TITLE);
+        expect(distance.left).to.be(0);
+        expect(distance.top).to.be(0);
+        done();
+      }, 1900);
+    });
+  };
+
+  var testCaretIndicatorIsAtEndOfSequenceDescription = function(testConfig) {
+    it('shows caret indicator at the end of last line of sequence description', function(done) {
+      var moveCaret = moveCaretOfOtherUserToLine(testConfig.lineNumber);
+      utils.executeAndWaitForCaretIndicatorToMove(moveCaret, function() {
+        var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(LINE_WITH_SEQ_DESCRIPTION_2);
+        expect(distance.left).to.be(0);
+        expect(distance.top).to.be(0);
+        done();
+      }, 1900);
+    });
+  };
+
+  before(function(done) {
+    multipleUsers = ep_script_copy_cut_paste_test_helper.multipleUsers;
+    utils         = ep_cursortrace_test_helper.utils;
+    smUtils       = ep_script_scene_marks_test_helper.utils;
+    eascUtils     = ep_script_toggle_view_test_helper.utils;
+
+    var openSM = function(done) {
+      multipleUsers.startActingLikeOtherUser();
+      smUtils.clickOnSceneMarkButtonOfLine(LINE_WITH_HEADING);
+      multipleUsers.startActingLikeThisUser();
+      done();
+    }
+
+    utils.openPadForMultipleUsers(this, createScript, function() {
+      utils.waitForCaretIndicatorToBeVisibleForBothUsers(function() {
+        // open SM for the other user, so all lines of the SM are visible
+        utils.executeAndWaitForCaretIndicatorToMove(openSM, done);
+      });
+    });
+  });
+
+  context('when EASC is [SEQ]', function() {
+    before(function() {
+      eascUtils.setEascMode(['sequence']);
+    });
+
+    [
+      // [group 1] tests for caret on lines that are visible
+      { test: testCaretIndicatorIsOnSamePositionOfCaret, lineNumber: LINE_WITH_SEQ_TITLE,         description: 'the sequence title'},
+      { test: testCaretIndicatorIsOnSamePositionOfCaret, lineNumber: LINE_WITH_SEQ_DESCRIPTION_1, description: 'the first line of sequence description'},
+      { test: testCaretIndicatorIsOnSamePositionOfCaret, lineNumber: LINE_WITH_SEQ_DESCRIPTION_2, description: 'the last line of sequence description'},
+      // [group 2] tests for caret on lines that are before first visible line
+      { test: testCaretIndicatorIsAtBeginningOfSequenceTitle, lineNumber: LINE_BEFORE_SEQ,           description: 'a line way before first visible line'},
+      { test: testCaretIndicatorIsAtBeginningOfSequenceTitle, lineNumber: LINE_WITH_ACT_TITLE,       description: 'the act title'},
+      { test: testCaretIndicatorIsAtBeginningOfSequenceTitle, lineNumber: LINE_WITH_ACT_DESCRIPTION, description: 'the act description'},
+      // [group 3] tests for caret on lines that are after last visible line
+      { test: testCaretIndicatorIsAtEndOfSequenceDescription, lineNumber: LINE_WITH_SCE_TITLE,       description: 'the synopsis title'},
+      { test: testCaretIndicatorIsAtEndOfSequenceDescription, lineNumber: LINE_WITH_SCE_DESCRIPTION, description: 'the synopsis description'},
+      { test: testCaretIndicatorIsAtEndOfSequenceDescription, lineNumber: LINE_WITH_HEADING,         description: 'the heading'},
+      { test: testCaretIndicatorIsAtEndOfSequenceDescription, lineNumber: LINE_AFTER_HEADING,        description: 'a line way after last visible line'},
+    ].forEach(function(testConfig) {
+        context('and line is ' + testConfig.description, function() {
+          before(function(done) {
+            forceCaretIndicatorToMove(done);
+          });
+
+          testConfig.test(testConfig);
+        });
+      });
+  });
+
+  context('when all EASC levels are disabled', function() {
+    before(function() {
+      eascUtils.setEascMode([]);
+    });
+
+    after(function(done) {
+      eascUtils.setEascMode(['script']);
+      utils.waitForCaretIndicatorToBeVisible(done);
+    });
+
+    it('hides the caret indicator', function(done) {
+      helper.waitFor(function() {
+        return !utils.getCaretIndicator().is(':visible');
+      }, 1900).done(done);
+    });
+  });
+});

--- a/static/tests/frontend/specs/tests.js
+++ b/static/tests/frontend/specs/tests.js
@@ -156,9 +156,7 @@ describe('ep_cursortrace - Basic Tests', function () {
     });
 
     it('removes the caret indicator', function(done) {
-      helper.waitFor(function() {
-        return !utils.getCaretIndicator().is(':visible');
-      }, 1900).done(done);
+      utils.waitForCaretIndicatorToBeHidden(done);
     });
   });
 


### PR DESCRIPTION
## Scenarios
- Show indicator at beginning of heading when caret is on hidden SM;
- Show indicator on closest visible line when EASC mode is on;
- Hide indicators when editor is disabled due to EASC mode changes;

## Rules for "closest visible line":
1. the caret is on a hidden SM:
   1.a. there is a visible SM on the same block above caret line => use the end of previous visible line
   1.b. there is NO visible SM on the same block above caret line => use the beginning of next visible line
2. the caret is on a hidden SE:
   2.a. SE is before 1st scene of script => use the beginning of next visible line
   2.b. SE belongs to a scene => use the end of previous visible line

## Also done on this PR
- extract logic to build caret indicator into `static/js/caret_indicator.js`;
- extract logic to store caret positions into`static/js/caret_location_manager.js`;

Fix https://trello.com/c/NmZfTnsz/1378.