### PR TITLE
[refactor] Transform modules into objects

### DIFF
--- a/static/js/api.js
+++ b/static/js/api.js
@@ -1,24 +1,28 @@
-// messages sent to outside
-var LIST_OF_USERS_ON_PAD = 'LIST_OF_USERS_ON_PAD';
+exports.initialize = function() {
+  return new api();
+}
 
-// messages coming from outside
-var GO_TO_CARET_OF_USER = 'GO_TO_CARET_OF_USER';
+var api = function() {
+  // messages sent to outside
+  this.LIST_OF_USERS_ON_PAD = 'LIST_OF_USERS_ON_PAD';
+  // messages coming from outside
+  this.GO_TO_CARET_OF_USER = 'GO_TO_CARET_OF_USER';
 
-exports.startListeningToInboundMessages = function() {
+  this.onGoToCaretOfUser = function() {};
+  this.startListeningToInboundMessages();
+}
+
+api.prototype.startListeningToInboundMessages = function() {
+  var self = this;
   window.addEventListener('message', function(e) {
-    _handleInboundCalls(e);
+    if (e.data.type === self.GO_TO_CARET_OF_USER) {
+      self.onGoToCaretOfUser(e.data.userId);
+    }
   });
 }
 
-var _handleInboundCalls = function _handleInboundCalls(e) {
-  if (e.data.type === GO_TO_CARET_OF_USER) {
-    onGoToCaretOfUser(e.data.userId);
-  }
-}
-
-var onGoToCaretOfUser = function() {};
-exports.setHandleGoToCaretOfUser = function(fn) {
-  onGoToCaretOfUser = fn;
+api.prototype.setHandleGoToCaretOfUser = function(fn) {
+  this.onGoToCaretOfUser = fn;
 }
 
 /*
@@ -27,17 +31,17 @@ exports.setHandleGoToCaretOfUser = function(fn) {
     userIds: ['a.psvBbHQGlbpH3OJX', 'a.xAvBb4KHlbpH3OJX']
   }
 */
-exports.triggerListOfUsersOnThisPad = function(userIds) {
+api.prototype.triggerListOfUsersOnThisPad = function(userIds) {
   var message = {
-    type: LIST_OF_USERS_ON_PAD,
+    type: this.LIST_OF_USERS_ON_PAD,
     userIds: userIds,
   };
-  _triggerEvent(message);
+  this._triggerEvent(message);
 }
 
-var _triggerEvent = function _triggerEvent(message) {
+api.prototype._triggerEvent = function _triggerEvent(message) {
   // send some extra info when running tests
-  if (_sendTestData()) {
+  if (this._sendTestData()) {
     message.fromUser = pad.getUserId();
   }
 
@@ -46,6 +50,6 @@ var _triggerEvent = function _triggerEvent(message) {
   target.postMessage(message, '*');
 }
 
-var _sendTestData = function() {
-  return pad && pad.plugins && pad.plugins.ep_cursortrace && pad.plugins.ep_cursortrace.sendTestDataOnApi;
+api.prototype._sendTestData = function() {
+  return pad.plugins.ep_cursortrace.sendTestDataOnApi;
 }

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -1,3 +1,5 @@
+var caretIndicator = require('./caret_indicator');
+
 exports.initialize = function() {
   return new api();
 }
@@ -8,7 +10,6 @@ var api = function() {
   // messages coming from outside
   this.GO_TO_CARET_OF_USER = 'GO_TO_CARET_OF_USER';
 
-  this.onGoToCaretOfUser = function() {};
   this.startListeningToInboundMessages();
 }
 
@@ -16,13 +17,9 @@ api.prototype.startListeningToInboundMessages = function() {
   var self = this;
   window.addEventListener('message', function(e) {
     if (e.data.type === self.GO_TO_CARET_OF_USER) {
-      self.onGoToCaretOfUser(e.data.userId);
+      caretIndicator.scrollEditorToShowCaretIndicatorOf(e.data.userId);
     }
   });
-}
-
-api.prototype.setHandleGoToCaretOfUser = function(fn) {
-  this.onGoToCaretOfUser = fn;
 }
 
 /*

--- a/static/js/caret_indicator.js
+++ b/static/js/caret_indicator.js
@@ -7,11 +7,7 @@ var caretPosition = require('./caret_position');
 var SMILEY = "&#9785;"
 var INDICATOR_HEIGHT = 16;
 
-exports.initialize = function() {
-  pad.plugins.ep_cursortrace.api.setHandleGoToCaretOfUser(scrollEditorToShowCaretIndicatorOf);
-}
-
-var scrollEditorToShowCaretIndicatorOf = function(authorId) {
+exports.scrollEditorToShowCaretIndicatorOf = function(authorId) {
   var $caretIndicator = getCaretIndicatorOf(authorId);
   $caretIndicator.get(0).scrollIntoView({ behavior: 'smooth' });
 }

--- a/static/js/caret_indicator.js
+++ b/static/js/caret_indicator.js
@@ -1,7 +1,6 @@
 var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 var Security = require('ep_etherpad-lite/static/js/security');
 
-var api = require('./api');
 var hiddenLines = require('./hidden_lines');
 var caretPosition = require('./caret_position');
 
@@ -9,8 +8,7 @@ var SMILEY = "&#9785;"
 var INDICATOR_HEIGHT = 16;
 
 exports.initialize = function() {
-  api.startListeningToInboundMessages();
-  api.setHandleGoToCaretOfUser(scrollEditorToShowCaretIndicatorOf);
+  pad.plugins.ep_cursortrace.api.setHandleGoToCaretOfUser(scrollEditorToShowCaretIndicatorOf);
 }
 
 var scrollEditorToShowCaretIndicatorOf = function(authorId) {

--- a/static/js/caret_indicator.js
+++ b/static/js/caret_indicator.js
@@ -2,7 +2,6 @@ var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 var Security = require('ep_etherpad-lite/static/js/security');
 
 var api = require('./api');
-var utils = require('./utils');
 var hiddenLines = require('./hidden_lines');
 var caretPosition = require('./caret_position');
 
@@ -82,7 +81,7 @@ var showIndicator = function($indicator, authorId) {
   var authorClassName = getAuthorClassName(authorId);
   $indicator.addClass(authorClassName);
 
-  var $outerdoc = utils.getOuterDoc();
+  var $outerdoc = getOuterDoc();
   // Remove all divs that already exist for this author
   $outerdoc.find("." + authorClassName).remove();
 
@@ -107,7 +106,7 @@ var removeCaretOf = exports.removeCaretOf;
 
 var getCaretIndicatorOf = function(authorId) {
   var authorClassName = getAuthorClassName(authorId);
-  return utils.getOuterDoc().find('.' + authorClassName);
+  return getOuterDoc().find('.' + authorClassName);
 }
 
 /*
@@ -121,4 +120,8 @@ var getAuthorClassName = function(authorId) {
     return c === '.' ? '-': 'z' + c.charCodeAt(0) + 'z';
   });
   return 'caret-' + cleanedAuthorClass;
+}
+
+var getOuterDoc = function() {
+  return pad.plugins.ep_cursortrace.utils.getOuterDoc();
 }

--- a/static/js/caret_location_manager.js
+++ b/static/js/caret_location_manager.js
@@ -1,8 +1,8 @@
-var api = require('./api');
-
 var caretLocationManager = function() {
   this.currentCaretLocations = {};
   this.pendingCaretLocations = {};
+  this.myAuthorId = pad.getUserId();
+  this.api = pad.plugins.ep_cursortrace.api;
 }
 
 caretLocationManager.prototype.activatePendingCaretLocations = function() {
@@ -16,8 +16,7 @@ caretLocationManager.prototype.getCaretLocations = function() {
 }
 
 caretLocationManager.prototype.getMyCurrentCaretLocation = function() {
-  var myAuthorId = pad.getUserId();
-  return this.currentCaretLocations[myAuthorId];
+  return this.currentCaretLocations[this.myAuthorId];
 }
 
 caretLocationManager.prototype.getCaretLocationsAfterLine = function(lineNumber) {
@@ -70,12 +69,12 @@ caretLocationManager.prototype._sendNewUsersListOnApi = function() {
   var authorsOnThisPad = Object.keys(this.currentCaretLocations);
 
   // don't need to send myAuthorId on the api
-  var myAuthorId = pad.getUserId();
+  var myAuthorId = this.myAuthorId;
   var authorsWithoutMe = authorsOnThisPad.filter(function(authorId) {
     return authorId !== myAuthorId;
   });
 
-  api.triggerListOfUsersOnThisPad(authorsWithoutMe);
+  this.api.triggerListOfUsersOnThisPad(authorsWithoutMe);
 }
 
 exports.initialize = function() {

--- a/static/js/caret_position.js
+++ b/static/js/caret_position.js
@@ -1,5 +1,4 @@
 var $ = require('ep_etherpad-lite/static/js/rjquery').$;
-var utils = require('./utils');
 
 /*
   Get position where caret should be placed -- on **pad outer**.
@@ -17,6 +16,8 @@ var utils = require('./utils');
     5. Remove the clone, as it is not needed anymore.
 */
 exports.getCaretPosition = function(caretLine, caretColumn) {
+  var utils = pad.plugins.ep_cursortrace.utils;
+
   // Are we ready to get caret position?
   var $caretDiv = utils.getLineOnEditor(caretLine);
   if ($caretDiv.length === 0) return;
@@ -101,6 +102,7 @@ var splitNodeOnCaretPosition = function(cloneTextNode, counter, caretColumn) {
 // Clone line with caret and copy its style
 var cloneLineWithStyle = function($caretDiv) {
   // Position of editor relative to client. Needed in final positioning
+  var utils = pad.plugins.ep_cursortrace.utils;
   var $padInnerFrame = utils.getPadOuter().find('iframe[name="ace_inner"]');
   var innerEditorPosition = $padInnerFrame[0].getBoundingClientRect();
 

--- a/static/js/hidden_lines.js
+++ b/static/js/hidden_lines.js
@@ -1,9 +1,9 @@
 // This code was initially adapted from ep_comments/static/js/textMarkIconsPosition.js,
 // but had been modified a lot since its creation.
 var $ = require('ep_etherpad-lite/static/js/rjquery').$;
-var utils = require('./utils');
 
 exports.getVisiblePosition = function(line, column) {
+  var utils = pad.plugins.ep_cursortrace.utils;
   var caretPosition = buildCaretPositionData(line, column);
 
   var $baseLine = utils.getLineOnEditor(line);
@@ -99,6 +99,7 @@ var lineIsBeforeFirstScene = function($line) {
 }
 
 var getLineNumberOfFirstScene = function() {
+  var utils = pad.plugins.ep_cursortrace.utils;
   var $beginningOfFirstScene = utils.getPadInner().find('div.sceneMark').first();
   return $beginningOfFirstScene.index();
 }

--- a/static/js/hide_carets_on_disabled_editor.js
+++ b/static/js/hide_carets_on_disabled_editor.js
@@ -1,9 +1,9 @@
 var eascUtils = require('ep_script_toggle_view/static/js/utils');
-var utils = require('./utils');
 
 var DISABLED_CONTAINER_CLASS = 'disabled';
 
 exports.initialize = function() {
+  var utils = pad.plugins.ep_cursortrace.utils;
   var $caretIndicatorContainer = utils.getPadOuter().find('#outerdocbody');
   utils.getPadInner().on(eascUtils.EASC_CHANGED_EVENT, function() {
     var editorIsDisabled = !eascUtils.isEditorEditable();

--- a/static/js/hide_carets_on_disabled_editor.js
+++ b/static/js/hide_carets_on_disabled_editor.js
@@ -2,7 +2,7 @@ var eascUtils = require('ep_script_toggle_view/static/js/utils');
 
 var DISABLED_CONTAINER_CLASS = 'disabled';
 
-exports.initialize = function() {
+exports.startListeningToEditorDisabling = function() {
   var utils = pad.plugins.ep_cursortrace.utils;
   var $caretIndicatorContainer = utils.getPadOuter().find('#outerdocbody');
   utils.getPadInner().on(eascUtils.EASC_CHANGED_EVENT, function() {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -10,10 +10,9 @@ var initiated = false;
 exports.postAceInit = function(hook_name, args, cb) {
   initiated = true;
 
-  pad.plugins = pad.plugins || {};
-  pad.plugins.ep_cursortrace = pad.plugins.ep_cursortrace || {};
-  pad.plugins.ep_cursortrace.timeToUpdateCaretPosition = TIME_TO_UPDATE_CARETS_POSITION;
-  pad.plugins.ep_cursortrace.utils = utils.initialize();
+  var thisPlugin = _getThisPlugin();
+  thisPlugin.timeToUpdateCaretPosition = TIME_TO_UPDATE_CARETS_POSITION;
+  thisPlugin.utils = utils.initialize();
 
   hideCaretsOnDisabledEditor.initialize();
   caretIndicator.initialize();
@@ -22,12 +21,14 @@ exports.postAceInit = function(hook_name, args, cb) {
 };
 
 var showCaretOfAuthorsAlreadyOnPad = function() {
+  var caretLocationManager = _getCaretLocationManager();
   caretLocationManager.activatePendingCaretLocations();
   var caretLocations = caretLocationManager.getCaretLocations();
   caretIndicator.buildAndShowIndicators(caretLocations);
 }
 
 var buildAndShowIndicatorsAfterLine = function(lineNumber) {
+  var caretLocationManager = _getCaretLocationManager();
   var caretLocations = caretLocationManager.getCaretLocationsAfterLine(lineNumber);
   caretIndicator.buildAndShowIndicators(caretLocations);
 }
@@ -50,6 +51,7 @@ exports.aceEditEvent = function(hook_name, args, cb) {
     var line = rep.selStart[0];
     // line might be a line with line attributes, so we need to ignore the '*' on the text
     var column = rep.selStart[1] - rep.lines.atIndex(line).lineMarker;
+    var caretLocationManager = _getCaretLocationManager();
     if (caretLocationManager.myPositionChanged(line, column)) {
       sendMessageWithCaretPosition(line, column);
     }
@@ -80,11 +82,13 @@ var sendMessageWithCaretPosition = function(line, column) {
   // Send the cursor position message to the server
   pad.collabClient.sendMessage(message);
   // Update set of caretLocations
+  var caretLocationManager = _getCaretLocationManager();
   caretLocationManager.updateCaretLocation(myAuthorId, line, column);
 }
 
 // we need to send our position to user who joined the pad, so our caret indicator is created there
 exports.handleClientMessage_USER_NEWINFO = function(hook, context, cb) {
+  var caretLocationManager = _getCaretLocationManager();
   var lastPositionOfMyCaret = caretLocationManager.getMyCurrentCaretLocation();
   if (lastPositionOfMyCaret) {
     sendMessageWithCaretPosition(lastPositionOfMyCaret.line, lastPositionOfMyCaret.column);
@@ -96,6 +100,7 @@ exports.handleClientMessage_USER_LEAVE = function(hook, context, cb) {
   // remove caret indicator on editor
   caretIndicator.removeCaretOf(userId);
   // update set of caretLocations
+  var caretLocationManager = _getCaretLocationManager();
   caretLocationManager.removeCaretLocationOf(userId);
 }
 
@@ -111,6 +116,7 @@ exports.handleClientMessage_CUSTOM = function(hook, context, cb) {
   if (pad.getUserId() === authorId) return false;
 
   // an author has sent this client a cursor position, we need to show it in the dom
+  var caretLocationManager = _getCaretLocationManager();
   if (!initiated) {
     // we are not ready yet to show caret indicator, so store it for when we are
     caretLocationManager.updatePendingCaretLocation(authorId, line, column);
@@ -118,4 +124,16 @@ exports.handleClientMessage_CUSTOM = function(hook, context, cb) {
     var caretLocation = caretLocationManager.updateCaretLocation(authorId, line, column);
     caretIndicator.buildAndShowIndicators([caretLocation]);
   }
+}
+
+var _getCaretLocationManager = function() {
+  var thisPlugin = _getThisPlugin();
+  thisPlugin.caretLocationManager = thisPlugin.caretLocationManager || caretLocationManager.initialize();
+  return thisPlugin.caretLocationManager;
+}
+
+var _getThisPlugin = function() {
+  pad.plugins = pad.plugins || {};
+  pad.plugins.ep_cursortrace = pad.plugins.ep_cursortrace || {};
+  return pad.plugins.ep_cursortrace;
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -11,8 +11,7 @@ var initiated = false;
 exports.postAceInit = function(hook_name, args, cb) {
   initiated = true;
   _getThisPlugin().timeToUpdateCaretPosition = TIME_TO_UPDATE_CARETS_POSITION;
-  hideCaretsOnDisabledEditor.initialize();
-  caretIndicator.initialize();
+  hideCaretsOnDisabledEditor.startListeningToEditorDisabling();
   showCaretOfAuthorsAlreadyOnPad();
   updateCaretsWhenAnUpdateMightHadAffectedTheirPositions();
 };

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -13,6 +13,7 @@ exports.postAceInit = function(hook_name, args, cb) {
   pad.plugins = pad.plugins || {};
   pad.plugins.ep_cursortrace = pad.plugins.ep_cursortrace || {};
   pad.plugins.ep_cursortrace.timeToUpdateCaretPosition = TIME_TO_UPDATE_CARETS_POSITION;
+  pad.plugins.ep_cursortrace.utils = utils.initialize();
 
   hideCaretsOnDisabledEditor.initialize();
   caretIndicator.initialize();
@@ -32,11 +33,12 @@ var buildAndShowIndicatorsAfterLine = function(lineNumber) {
 }
 
 var updateCaretsWhenAnUpdateMightHadAffectedTheirPositions = function() {
-  utils.getPadInner().on(LINE_CHANGED_EVENT, function(e, data) {
+  var thisPlugin = pad.plugins.ep_cursortrace;
+  thisPlugin.utils.getPadInner().on(LINE_CHANGED_EVENT, function(e, data) {
     var lineOfChange = data.lineNumber;
     setTimeout(function() {
       buildAndShowIndicatorsAfterLine(lineOfChange);
-    }, pad.plugins.ep_cursortrace.timeToUpdateCaretPosition);
+    }, thisPlugin.timeToUpdateCaretPosition);
   });
 }
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,4 +1,5 @@
 var LINE_CHANGED_EVENT = require('ep_comments_page/static/js/utils').LINE_CHANGED_EVENT;
+var api = require('./api');
 var utils = require('./utils');
 var caretIndicator = require('./caret_indicator');
 var caretLocationManager = require('./caret_location_manager');
@@ -9,11 +10,7 @@ var initiated = false;
 
 exports.postAceInit = function(hook_name, args, cb) {
   initiated = true;
-
-  var thisPlugin = _getThisPlugin();
-  thisPlugin.timeToUpdateCaretPosition = TIME_TO_UPDATE_CARETS_POSITION;
-  thisPlugin.utils = utils.initialize();
-
+  _getThisPlugin().timeToUpdateCaretPosition = TIME_TO_UPDATE_CARETS_POSITION;
   hideCaretsOnDisabledEditor.initialize();
   caretIndicator.initialize();
   showCaretOfAuthorsAlreadyOnPad();
@@ -127,13 +124,22 @@ exports.handleClientMessage_CUSTOM = function(hook, context, cb) {
 }
 
 var _getCaretLocationManager = function() {
-  var thisPlugin = _getThisPlugin();
-  thisPlugin.caretLocationManager = thisPlugin.caretLocationManager || caretLocationManager.initialize();
-  return thisPlugin.caretLocationManager;
+  return _getThisPlugin().caretLocationManager;
 }
 
 var _getThisPlugin = function() {
-  pad.plugins = pad.plugins || {};
-  pad.plugins.ep_cursortrace = pad.plugins.ep_cursortrace || {};
+  if (!pad.plugins || !pad.plugins.ep_cursortrace) {
+    // plugin modules not initialized yet
+    pad.plugins = pad.plugins || {};
+    pad.plugins.ep_cursortrace = pad.plugins.ep_cursortrace || {};
+    initializePlugin(pad.plugins.ep_cursortrace);
+  }
+
   return pad.plugins.ep_cursortrace;
+}
+
+var initializePlugin = function(thisPlugin) {
+  thisPlugin.utils = utils.initialize();
+  thisPlugin.api = api.initialize();
+  thisPlugin.caretLocationManager = caretLocationManager.initialize();
 }

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -1,28 +1,28 @@
 var $ = require('ep_etherpad-lite/static/js/rjquery').$;
 
-// Easier access to outer pad
-var padOuter;
-exports.getPadOuter = function() {
-  padOuter = padOuter || $('iframe[name="ace_outer"]').contents();
-  return padOuter;
+var utils = {
+  getPadOuter: function() {
+    this.padOuter = this.padOuter || $('iframe[name="ace_outer"]').contents();
+    return this.padOuter;
+  },
+
+  getPadInner: function() {
+    this.padInner = this.padInner || this.getPadOuter().find('iframe[name="ace_inner"]').contents();
+    return this.padInner;
+  },
+
+  getOuterDoc: function() {
+    this.$outerDocBody = this.$outerDocBody || this.getPadOuter().find("#outerdocbody");
+    return this.$outerDocBody;
+  },
+
+  getLineOnEditor: function(lineNumber) {
+    // +1 as Etherpad line numbers start at 0
+    var nthChild = lineNumber + 1;
+    return this.getPadInner().find('#innerdocbody > div:nth-child(' + nthChild + ')');
+  },
 }
 
-// Easier access to inner pad
-var padInner;
-exports.getPadInner = function() {
-  padInner = padInner || exports.getPadOuter().find('iframe[name="ace_inner"]').contents();
-  return padInner;
-}
-
-// Easier access to outer doc body
-var $outerDocBody;
-exports.getOuterDoc = function() {
-  $outerDocBody = $outerDocBody || exports.getPadOuter().find("#outerdocbody");
-  return $outerDocBody;
-}
-
-exports.getLineOnEditor = function(lineNumber) {
-  // +1 as Etherpad line numbers start at 0
-  var nthChild = lineNumber + 1;
-  return exports.getPadInner().find('#innerdocbody > div:nth-child(' + nthChild + ')');
+exports.initialize = function() {
+  return utils;
 }


### PR DESCRIPTION
Address code review suggestion of #4 not addressed by its last commit (https://github.com/storytouch/ep_cursortrace/pull/4/commits/7d8817f61e88e70869e9a50a486b4389f17faf62).

Modules affected:
- [x] `utils.js`
- [x] `api.js`;
- [x] `caret_location_manager.js`;