### PR TITLE
[refactor] Show caret with user color defined on TK

### DIFF
--- a/static/css/cursortrace.css
+++ b/static/css/cursortrace.css
@@ -10,8 +10,9 @@
   display: block;
   width: 2px;
   height: 26px;
-  background-color: black;
   opacity: .5;
+  /* make stick & name have the same color */
+  background-color: currentColor;
 }
 
 .caretindicator p {
@@ -19,6 +20,7 @@
   margin-top:-24px;
   padding-left:4px;
   padding-right:4px;
+  color: black;
 }
 
 .caretindicator.stickDown {

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -1,4 +1,4 @@
-var caretIndicator = require('./caret_indicator');
+var doNothing = function() {}
 
 exports.initialize = function() {
   return new api();
@@ -6,9 +6,13 @@ exports.initialize = function() {
 
 var api = function() {
   // messages sent to outside
-  this.LIST_OF_USERS_ON_PAD = 'LIST_OF_USERS_ON_PAD';
+  this.LIST_OF_USERS_ON_PAD = 'caret-users_on_pad';
   // messages coming from outside
-  this.GO_TO_CARET_OF_USER = 'GO_TO_CARET_OF_USER';
+  this.GO_TO_CARET_OF_USER = 'caret-go_to_caret_of_user';
+  this.SET_USERS_COLORS = 'caret-set_users_colors';
+
+  this.onGoToCaretOfUser = doNothing;
+  this.onSetUsersColors = doNothing;
 
   this.startListeningToInboundMessages();
 }
@@ -16,15 +20,32 @@ var api = function() {
 api.prototype.startListeningToInboundMessages = function() {
   var self = this;
   window.addEventListener('message', function(e) {
-    if (e.data.type === self.GO_TO_CARET_OF_USER) {
-      caretIndicator.scrollEditorToShowCaretIndicatorOf(e.data.userId);
-    }
+    self._handleInboundCalls(e);
   });
+}
+
+api.prototype._handleInboundCalls = function _handleInboundCalls(e) {
+  switch (e.data.type) {
+    case this.GO_TO_CARET_OF_USER:
+      this.onGoToCaretOfUser(e.data.userId);
+      break;
+    case this.SET_USERS_COLORS:
+      this.onSetUsersColors(e.data.usersColors);
+      break;
+  }
+}
+
+api.prototype.setHandleOnGoToCaretOfUser = function(fn) {
+  this.onGoToCaretOfUser = fn;
+}
+
+api.prototype.onUsersColorsChange = function(fn) {
+  this.onSetUsersColors = fn;
 }
 
 /*
   message: {
-    type: 'LIST_OF_USERS_ON_PAD',
+    type: 'caret-users_on_pad',
     userIds: ['a.psvBbHQGlbpH3OJX', 'a.xAvBb4KHlbpH3OJX']
   }
 */

--- a/static/js/colors.js
+++ b/static/js/colors.js
@@ -1,0 +1,61 @@
+var _ = require('ep_etherpad-lite/static/js/underscore');
+
+// [A1,...,A10]
+var COLORS_A = _(_.range(1, 11)).map(function(i) { return 'A' + i });
+// [B11,...,B20]
+var COLORS_B = _(_.range(11, 21)).map(function(i) { return 'B' + i });
+// [C21,...,C30]
+var COLORS_C = _(_.range(21, 31)).map(function(i) { return 'C' + i });
+// [D21,...,D30]
+var COLORS_D = _(_.range(31, 41)).map(function(i) { return 'D' + i });
+
+exports.COLOR_NAMES = _.union(COLORS_A, COLORS_B, COLORS_C, COLORS_D);
+
+exports.getColorHash = function(colorName, alpha) {
+  alpha = alpha == undefined ? 1 : alpha;
+  var rgb = COLORS_RGB[colorName] || COLORS_RGB['A2']; // default to A2
+  return 'rgba(' + rgb + ', ' + alpha + ')';
+}
+
+var COLORS_RGB = {
+  A1:  '255, 0  , 0',
+  A2:  '255, 126, 0',
+  A3:  '255, 204, 0',
+  A4:  '80 , 240, 0',
+  A5:  '0  , 194, 0',
+  A6:  '20 , 240, 242',
+  A7:  '22 , 170, 255',
+  A8:  '32 , 110, 255',
+  A9:  '160, 45 , 220',
+  A10: '255, 24 , 128',
+  B11: '162, 8  , 12',
+  B12: '162, 83 , 8',
+  B13: '164, 135, 32',
+  B14: '54 , 153, 8',
+  B15: '6  , 123, 6',
+  B16: '20 , 152, 154',
+  B17: '22 , 112, 163',
+  B18: '29 , 76 , 163',
+  B19: '105, 35 , 140',
+  B20: '163, 24 , 86',
+  C21: '234, 144, 146',
+  C22: '234, 189, 144',
+  C23: '237, 220, 160',
+  C24: '169, 227, 142',
+  C25: '140, 207, 140',
+  C26: '150, 227, 229',
+  C27: '153, 205, 235',
+  C28: '158, 185, 235',
+  C29: '202, 162, 222',
+  C30: '235, 153, 190',
+  D31: '105, 45 , 60',
+  D32: '125, 83 , 55',
+  D33: '150, 140, 90',
+  D34: '110, 135, 95',
+  D35: '75 , 100, 85',
+  D36: '75 , 125, 130',
+  D37: '65 , 105, 125',
+  D38: '75 , 85 , 105',
+  D39: '90 , 65 , 105',
+  D40: '105, 70 , 85',
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -17,14 +17,20 @@ exports.postAceInit = function(hook_name, args, cb) {
 };
 
 var showCaretOfAuthorsAlreadyOnPad = function() {
-  var caretLocationManager = _getCaretLocationManager();
+  var thisPlugin = _getThisPlugin();
+  var caretLocationManager = thisPlugin.caretLocationManager;
+  var caretIndicator = thisPlugin.caretIndicator;
+
   caretLocationManager.activatePendingCaretLocations();
   var caretLocations = caretLocationManager.getCaretLocations();
   caretIndicator.buildAndShowIndicators(caretLocations);
 }
 
 var buildAndShowIndicatorsAfterLine = function(lineNumber) {
-  var caretLocationManager = _getCaretLocationManager();
+  var thisPlugin = _getThisPlugin();
+  var caretLocationManager = thisPlugin.caretLocationManager;
+  var caretIndicator = thisPlugin.caretIndicator;
+
   var caretLocations = caretLocationManager.getCaretLocationsAfterLine(lineNumber);
   caretIndicator.buildAndShowIndicators(caretLocations);
 }
@@ -92,11 +98,14 @@ exports.handleClientMessage_USER_NEWINFO = function(hook, context, cb) {
 }
 
 exports.handleClientMessage_USER_LEAVE = function(hook, context, cb) {
+  var thisPlugin = _getThisPlugin();
+  var caretLocationManager = thisPlugin.caretLocationManager;
+  var caretIndicator = thisPlugin.caretIndicator;
+
   var userId = context.payload.userId;
   // remove caret indicator on editor
   caretIndicator.removeCaretOf(userId);
   // update set of caretLocations
-  var caretLocationManager = _getCaretLocationManager();
   caretLocationManager.removeCaretLocationOf(userId);
 }
 
@@ -112,7 +121,9 @@ exports.handleClientMessage_CUSTOM = function(hook, context, cb) {
   if (pad.getUserId() === authorId) return false;
 
   // an author has sent this client a cursor position, we need to show it in the dom
-  var caretLocationManager = _getCaretLocationManager();
+  var thisPlugin = _getThisPlugin();
+  var caretLocationManager = thisPlugin.caretLocationManager;
+  var caretIndicator = thisPlugin.caretIndicator;
   if (!initiated) {
     // we are not ready yet to show caret indicator, so store it for when we are
     caretLocationManager.updatePendingCaretLocation(authorId, line, column);
@@ -141,4 +152,5 @@ var initializePlugin = function(thisPlugin) {
   thisPlugin.utils = utils.initialize();
   thisPlugin.api = api.initialize();
   thisPlugin.caretLocationManager = caretLocationManager.initialize();
+  thisPlugin.caretIndicator = caretIndicator.initialize();
 }

--- a/static/tests/frontend/specs/_apiUtils.js
+++ b/static/tests/frontend/specs/_apiUtils.js
@@ -1,7 +1,7 @@
 var ep_cursortrace_test_helper = ep_cursortrace_test_helper || {};
 ep_cursortrace_test_helper.apiUtils = {
   /**** messages sent to outside ****/
-  LIST_OF_USERS_ON_PAD: 'LIST_OF_USERS_ON_PAD',
+  LIST_OF_USERS_ON_PAD: 'caret-users_on_pad',
 
   lastDataSent: {},
 
@@ -46,14 +46,26 @@ ep_cursortrace_test_helper.apiUtils = {
   },
 
   /**** messages coming from outside ****/
-  GO_TO_CARET_OF_USER: 'GO_TO_CARET_OF_USER',
+  GO_TO_CARET_OF_USER: 'caret-go_to_caret_of_user',
+  SET_USERS_COLORS: 'caret-set_users_colors',
 
   simulateCallToGoToCaretOfUser: function(userId) {
     var message = {
       type: this.GO_TO_CARET_OF_USER,
       userId: userId,
     };
+    this._simulateCallOfMessage(message);
+  },
 
+  simulateCallToSetUsersColors: function(usersColors) {
+    var message = {
+      type: this.SET_USERS_COLORS,
+      usersColors: usersColors,
+    };
+    this._simulateCallOfMessage(message);
+  },
+
+  _simulateCallOfMessage: function(message) {
     var inboundApiEventsTarget = helper.padChrome$.window;
     inboundApiEventsTarget.postMessage(message, '*');
   },

--- a/static/tests/frontend/specs/api-inbound.js
+++ b/static/tests/frontend/specs/api-inbound.js
@@ -16,34 +16,58 @@ describe('ep_cursortrace - api - inbound messages', function() {
     }).done(done);
   }
 
-  var moveCaretOutOfViewport = function(done) {
-    utils.placeCaretOfOtherUserAtEndOfLine(MULTIPLE_LINES - 1, done);
-  }
-
   before(function(done) {
     utils = ep_cursortrace_test_helper.utils;
     apiUtils = ep_cursortrace_test_helper.apiUtils;
 
     utils.openPadForMultipleUsers(this, createLongScript, function() {
+      utils.waitForCaretIndicatorToBeVisibleForBothUsers(done);
+    });
+  });
+
+  describe('GO_TO_CARET_OF_USER', function() {
+    before(function(done) {
       // move caret of other user to the end of pad, so it is out of viewport
-      utils.waitForCaretIndicatorToBeVisibleForBothUsers(function() {
-        utils.executeAndWaitForCaretIndicatorToMove(moveCaretOutOfViewport, done);
+      var moveCaretOutOfViewport = function(done) {
+        utils.placeCaretOfOtherUserAtEndOfLine(MULTIPLE_LINES - 1, done);
+      }
+      utils.executeAndWaitForCaretIndicatorToMove(moveCaretOutOfViewport, done);
+    });
+
+    context('when user requires to go to caret of other user', function() {
+      before(function() {
+        apiUtils.simulateCallToGoToCaretOfUser(utils.otherUserId);
+      });
+
+      it('scrolls editor until the caret of target user is visible', function(done) {
+        var isVisibleOnViewport = ep_comments_page_test_helper.utils.isVisibleOnViewport;
+        var $caretIndicator = utils.getCaretIndicator();
+
+        helper.waitFor(function() {
+          return isVisibleOnViewport($caretIndicator.get(0));
+        }).done(done);
       });
     });
   });
 
-  context('when user requires to go to caret of other user', function() {
-    before(function() {
-      apiUtils.simulateCallToGoToCaretOfUser(utils.otherUserId);
-    });
+  describe('SET_USERS_COLORS', function() {
+    context('when users colors are updated', function() {
+      var COLOR_NAME = 'A5';
+      var COLOR_HASH = 'rgb(0, 194, 0)';
 
-    it('scrolls editor until the caret of target user is visible', function(done) {
-      var isVisibleOnViewport = ep_comments_page_test_helper.utils.isVisibleOnViewport;
-      var $caretIndicator = utils.getCaretIndicator();
+      before(function() {
+        var usersColors = {};
+        usersColors[utils.otherUserId] = COLOR_NAME;
+        apiUtils.simulateCallToSetUsersColors(usersColors);
+      });
 
-      helper.waitFor(function() {
-        return isVisibleOnViewport($caretIndicator.get(0));
-      }).done(done);
+      it('shows caret indicator with the provided color', function(done) {
+        var getBackgroundColorOf = ep_script_touches_test_helper.utils.getBackgroundColorOf;
+        helper.waitFor(function() {
+          var $caretIndicator = utils.getCaretIndicator();
+          return getBackgroundColorOf($caretIndicator) === COLOR_HASH;
+        }).done(done);
+      });
     });
   });
 });


### PR DESCRIPTION
- move colors definitions from ep_tag to ep_cursortrace;
- transform `caret_indicator.js` into an object;
- handle new API inbound message: "caret-set_users_colors". Receives a map of `authorID => colorName`;
- show caret indicator "stick" with the same color of author name;

This is part of the changes to implement https://trello.com/c/B1En1Wic/1379.

Other PRs on this batch: 
- https://github.com/storytouch/ep_script_touches/pull/52
- https://github.com/storytouch/web/pull/336