### PR TITLE
[feat] Allow API to handle GO_TO_CARET_OF_USER with my author id

### DIFF
--- a/static/js/caret_indicator.js
+++ b/static/js/caret_indicator.js
@@ -14,18 +14,27 @@ exports.initialize = function() {
 }
 
 var caretIndicator = function() {
+  this.myAuthorId = pad.getUserId();
+  this.thisPlugin = pad.plugins.ep_cursortrace;
   // map userId => colorName. Ex: { 'a.G1RIWyGaHlXbbYi9' : 'A8' }
   this.usersColors = {};
-  this.myAuthorId = pad.getUserId();
 
-  var api = pad.plugins.ep_cursortrace.api;
+  var api = this.thisPlugin.api;
   api.setHandleOnGoToCaretOfUser(this.scrollEditorToShowCaretIndicatorOf.bind(this));
   api.onUsersColorsChange(this.setUsersColors.bind(this));
 }
 
 caretIndicator.prototype.scrollEditorToShowCaretIndicatorOf = function(authorId) {
-  var $caretIndicator = this._getCaretIndicatorOf(authorId);
-  $caretIndicator.get(0).scrollIntoView({ behavior: 'smooth' });
+  // we don't render the caret indicator of ourselves, so we need to use the
+  // line on padInner as reference
+  var $target = (authorId === this.myAuthorId) ? this._getMyCurrentLine() : this._getCaretIndicatorOf(authorId);
+  $target.get(0).scrollIntoView({ behavior: 'smooth' });
+}
+
+caretIndicator.prototype._getMyCurrentLine = function() {
+  var myCurrentLocation = this.thisPlugin.caretLocationManager.getMyCurrentCaretLocation();
+  var $myCurrentLine = this.thisPlugin.utils.getLineOnEditor(myCurrentLocation.line);
+  return $myCurrentLine;
 }
 
 caretIndicator.prototype.setUsersColors = function(usersColors) {

--- a/static/js/caret_indicator.js
+++ b/static/js/caret_indicator.js
@@ -29,6 +29,15 @@ caretIndicator.prototype.scrollEditorToShowCaretIndicatorOf = function(authorId)
   // line on padInner as reference
   var $target = (authorId === this.myAuthorId) ? this._getMyCurrentLine() : this._getCaretIndicatorOf(authorId);
   $target.get(0).scrollIntoView({ behavior: 'smooth' });
+
+  // if user needs to click out of editor (padInner) to trigger the scroll to caret of target author,
+  // the editor will lose focus, so user cannot start typing right away.
+  // Force focus to be on editor to avoid that.
+  this._makeSureEditorHasTheFocus();
+}
+
+caretIndicator.prototype._makeSureEditorHasTheFocus = function() {
+  this.thisPlugin.utils.getPadOuter().find('iframe[name="ace_inner"]').get(0).contentWindow.focus();
 }
 
 caretIndicator.prototype._getMyCurrentLine = function() {

--- a/static/tests/frontend/specs/api-inbound.js
+++ b/static/tests/frontend/specs/api-inbound.js
@@ -39,12 +39,33 @@ describe('ep_cursortrace - api - inbound messages', function() {
         apiUtils.simulateCallToGoToCaretOfUser(utils.otherUserId);
       });
 
-      it('scrolls editor until the caret of target user is visible', function(done) {
+      it('scrolls editor until the caret indicator of target user is visible', function(done) {
         var isVisibleOnViewport = ep_comments_page_test_helper.utils.isVisibleOnViewport;
         var $caretIndicator = utils.getCaretIndicator();
 
         helper.waitFor(function() {
           return isVisibleOnViewport($caretIndicator.get(0));
+        }).done(done);
+      });
+    });
+
+    context('when user requires to go to caret of my user', function() {
+      before(function() {
+        // move my caret to the beginning of pad...
+        var $lineToPlaceMyCaret = utils.getLine(0);
+        $lineToPlaceMyCaret.sendkeys('{selectall}{rightarrow}');
+
+        // ... then scroll viewport away from that line
+        var $editor = helper.padOuter$('#outerdocbody');
+        $editor.parent().scrollTop($editor.height() / 2);
+
+        apiUtils.simulateCallToGoToCaretOfUser(utils.myUserId);
+      });
+
+      it('scrolls editor until the caret of my user is visible', function(done) {
+        var $editor = helper.padOuter$('#outerdocbody');
+        helper.waitFor(function() {
+          return $editor.parent().scrollTop() === 0;
         }).done(done);
       });
     });


### PR DESCRIPTION
Use padInner line as reference to scroll editor, instead of caret indicator.

Implement part of https://trello.com/c/NpKpf7WP/1416.