### PR TITLE
[feat] Enable author name to be shown/hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ Important: A caret is not a cursor, a cursor is what your mouse uses.. A caret i
 
 ## Customization
 
-By default, the caret indicator is rendered for 2 seconds, then it fades out. If you want to change this behavior, you can configure your `settings.json`:
+By default, the caret indicator is rendered for 2 seconds, then it fades out. If you want to change this behavior, you can configure your `settings.json`. You can also keep caret indicator always visible, and fade out only the author name:
 
 ```
   "ep_cursortrace":{
-    "fade_out_timeout": 2000 // in milliseconds. A 0 timeout means caret indicators are never hidden
+    // timeouts in milliseconds. A 0 timeout means caret indicators and/or author names are never hidden
+    "fade_out_timeout": 2000,
+    "fade_out_name_timeout": 2000
   }
 ```
 

--- a/settings.js
+++ b/settings.js
@@ -1,7 +1,18 @@
 settings = require('ep_etherpad-lite/node/utils/Settings');
 
 exports.clientVars = function (hook, context, cb) {
-  var fade_out_timeout = settings.ep_cursortrace ? settings.ep_cursortrace.fade_out_timeout : 2000;
+  var fade_out_timeout = getValueOrDefaultTo('fade_out_timeout', 2000);
+  var fade_out_name_timeout = getValueOrDefaultTo('fade_out_name_timeout', 0);
 
-  return cb({ ep_cursortrace: { fade_out_timeout: fade_out_timeout } });
+  return cb({
+    ep_cursortrace: {
+      fade_out_timeout: fade_out_timeout,
+      fade_out_name_timeout: fade_out_name_timeout,
+    }
+  });
 };
+
+var getValueOrDefaultTo = function(settingName, defaultValue) {
+  var valueOnSettings = settings.ep_cursortrace[settingName];
+  return valueOnSettings === undefined ? defaultValue : valueOnSettings;
+}

--- a/static/css/cursortrace.css
+++ b/static/css/cursortrace.css
@@ -1,36 +1,59 @@
 .caretindicator {
-  max-width:300px;
-  margin: -14px 0;
-  position:absolute;
-  opacity:1;
+  max-width: 300px;
+  margin: 0 -2px; /* -2px: inverse of horizontal margins of .caretindicator:before */
+  height: 16px;
+  position: absolute;
+  opacity: .5;
 }
 
+/* caret "bar" */
 .caretindicator:before {
   content: "";
   display: block;
   width: 2px;
-  height: 26px;
-  opacity: .5;
+  height: 100%;
+  margin: 0 2px;
   /* make stick & name have the same color */
   background-color: currentColor;
 }
 
-.caretindicator p {
-  position:relative;
-  margin-top:-24px;
-  padding-left:4px;
-  padding-right:4px;
+/* caret name */
+.caretindicator .name {
+  /* place name on top of caret bar */
+  position: relative;
+  margin-top: -32px;
+  padding: 3px;
+  /* make stick & name have the same color */
+  background-color: currentColor;
+}
+
+.caretindicator .name p {
   color: black;
 }
 
-.caretindicator.stickDown {
-  margin-top: 14px;
+/* styles for caret indicator with no visible author */
+.caretindicator .name {
+  max-width: 100%;
+  max-height: 100%;
+  overflow: hidden;
+
+  /* animate showing/hiding author name */
+  will-change: max-height, max-width;
+  -webkit-transition: all 500ms ease-in-out;
+  -moz-transition: all 500ms ease-in-out;
+  -ms-transition: all 500ms ease-in-out;
+  -o-transition: all 500ms ease-in-out;
+  transition: all 500ms ease-in-out;
 }
-.caretindicator.stickDown:before {
-  margin-top: -10px;
+.caretindicator.no-name .name {
+  max-width: 0;
+  max-height: 0;
+  margin-top: -22px;
 }
-.caretindicator.stickDown p {
-  margin-top: -14px;
+
+/* styles for caret indicator with author name below target position */
+.caretindicator.stickDown .name {
+  margin-top: 0;
 }
 
 /* hide caret indicator when pad is disabled */

--- a/static/js/caret_indicator.js
+++ b/static/js/caret_indicator.js
@@ -99,14 +99,14 @@ caretIndicator.prototype._buildIndicator = function(user, position) {
   // Location of stick direction IE up or down
   var location = position.top >= INDICATOR_HEIGHT ? 'stickUp' : 'stickDown';
   var authorName = this._getAuthorName(user);
+  var author = '<div class="name"><p>' + authorName + '</p></div>'
   var classes = 'class="' + CARET_INDICATOR_CLASS + ' ' + location + '"';
   var timestamp = 'timestamp="' + Date.now() + '"';
 
   // Create a new Div for this author
-  var $indicator = $('<div ' + classes + ' ' + timestamp + '><p>' + authorName + '</p></div>');
+  var $indicator = $('<div ' + classes + ' ' + timestamp + '>' + author + '</div>');
   $indicator.data('user_id', user.userId);
   $indicator.css({
-    height:  INDICATOR_HEIGHT + 'px',
     left: position.left + 'px',
     top: position.top + 'px',
   });
@@ -119,7 +119,6 @@ caretIndicator.prototype._setColorOf = function($indicator) {
   var userId = $indicator.data('user_id');
   var color = this._getAuthorColor(userId);
   $indicator.css({
-    'background-color': color,
     color: color,
   });
 }
@@ -140,13 +139,23 @@ caretIndicator.prototype._showIndicator = function($indicator, authorId) {
 }
 
 caretIndicator.prototype._fadeOutCaretIndicator = function($indicator) {
-  if (clientVars.ep_cursortrace.fade_out_timeout) {
-    // After a while, fade it out :)
+  var settings = clientVars.ep_cursortrace;
+
+  if (settings.fade_out_timeout) {
     setTimeout(function(){
       $indicator.fadeOut(500, function(){
         $indicator.remove();
       });
-    }, clientVars.ep_cursortrace.fade_out_timeout);
+    }, settings.fade_out_timeout);
+  } else if (settings.fade_out_name_timeout) {
+    // we use CSS animations to show/hide author name
+    var hideAuthorName = function() { $indicator.addClass('no-name') };
+    var showAuthorName = function() { $indicator.removeClass('no-name') };
+
+    // fade name after a while...
+    setTimeout(hideAuthorName, settings.fade_out_name_timeout);
+    // ... and show it again while mouse is over
+    $indicator.on('mouseenter', showAuthorName).on('mouseleave', hideAuthorName);
   }
 }
 

--- a/static/tests/frontend/specs/api-inbound.js
+++ b/static/tests/frontend/specs/api-inbound.js
@@ -82,11 +82,11 @@ describe('ep_cursortrace - api - inbound messages', function() {
         apiUtils.simulateCallToSetUsersColors(usersColors);
       });
 
-      it('shows caret indicator with the provided color', function(done) {
+      it('shows author name with the provided color', function(done) {
         var getBackgroundColorOf = ep_script_touches_test_helper.utils.getBackgroundColorOf;
         helper.waitFor(function() {
-          var $caretIndicator = utils.getCaretIndicator();
-          return getBackgroundColorOf($caretIndicator) === COLOR_HASH;
+          var $authorName = utils.getCaretIndicator().find('.name');
+          return getBackgroundColorOf($authorName) === COLOR_HASH;
         }).done(done);
       });
     });


### PR DESCRIPTION
Create a setting to control if the author should be always visible or not. By default it is not hidden. Animate author name showing/hiding.

Implement part of https://trello.com/c/baVsGyAD/1376.

![animacao_caret](https://user-images.githubusercontent.com/836386/43409255-cf414f96-93f9-11e8-8622-392396ff48c4.gif)
