### PR TITLE
[fix:ux] Allow user to click closer to indicator and start typing

### DIFF
--- a/static/css/cursortrace.css
+++ b/static/css/cursortrace.css
@@ -10,8 +10,11 @@
   content: "";
   display: block;
   width: 2px;
+
+  /* 15px: same value of INDICATOR_HEIGHT (see caret_indicator.js) */
   height: 15px;
-  margin: 0 1px;
+  margin: 15px 1px 0 1px;
+
   /* make stick & name have the same color */
   background-color: currentColor;
 }
@@ -22,7 +25,7 @@
   font-size: 11px;
   /* place name on top of caret bar */
   position: relative;
-  margin-top: -30px;
+  margin-top: -30px; /* 2*INDICATOR_HEIGHT */
   padding: 1px 3px;
   /* make stick & name have the same color */
   background-color: currentColor;

--- a/static/js/caret_indicator.js
+++ b/static/js/caret_indicator.js
@@ -7,7 +7,8 @@ var caretPosition = require('./caret_position');
 
 var SMILEY = '&#9785;'
 var CARET_INDICATOR_CLASS = 'caretindicator'
-var INDICATOR_HEIGHT = 16;
+// If you change value of INDICATOR_HEIGHT, you also need to change the values on CSS
+var INDICATOR_HEIGHT = 15;
 
 exports.initialize = function() {
   return new caretIndicator();
@@ -108,7 +109,7 @@ caretIndicator.prototype._buildIndicator = function(user, position) {
   $indicator.data('user_id', user.userId);
   $indicator.css({
     left: position.left + 'px',
-    top: position.top + 'px',
+    top: (position.top - INDICATOR_HEIGHT) + 'px',
   });
   this._setColorOf($indicator);
 

--- a/static/tests/frontend/specs/_utils.js
+++ b/static/tests/frontend/specs/_utils.js
@@ -73,7 +73,11 @@ ep_cursortrace_test_helper.utils = {
     }
     var helperMarkPosition = $helperMark.position();
 
-    var top  = caretPosition.top  - helperMarkPosition.top;
+    // +15: in order to improve UX when clicking close to the indicator, we shift the
+    // whole indicator 15px up. So we need to adjust its position when comparing to
+    // an element on editor
+    var actualCaretTop = caretPosition.top + 15;
+    var top  = actualCaretTop  - helperMarkPosition.top;
     var left = caretPosition.left - helperMarkPosition.left;
 
     $helperMark.remove();


### PR DESCRIPTION
Shift the entire caret indicator 15px up, so when the user clicks close to the area of the indicator the focus won't be sent to the indicator itself. Instead, the focus goes to the editor, so user can start typing right away.

Fix https://trello.com/c/RAb4lVEu/1476.

### Before the fix:
![bug-focus-caret-staging](https://user-images.githubusercontent.com/836386/44419230-f7e8dc80-a550-11e8-8ed9-e93e7bb6295d.gif)

### After the fix:
![bug-focus-caret-local](https://user-images.githubusercontent.com/836386/44419242-00d9ae00-a551-11e8-8cb9-8c6ec89a9513.gif)
