### PR TITLE
[fix] Update name font color when user edits

### DIFF
--- a/static/js/caret_indicator.js
+++ b/static/js/caret_indicator.js
@@ -120,7 +120,7 @@ caretIndicator.prototype._buildIndicator = function(user, position) {
     top: (position.top - INDICATOR_HEIGHT) + 'px',
   });
   this._setColorOf($indicator);
-
+  this._setColorOfTextOfCaretIndicator($indicator);
   return $indicator;
 }
 

--- a/static/js/caret_indicator.js
+++ b/static/js/caret_indicator.js
@@ -59,7 +59,6 @@ caretIndicator.prototype._updateColorsOfCurrentIndicators = function() {
   $caretIndicator.each(function() {
     var $caretIndicator = $(this);
     self._setColorOf($caretIndicator);
-    self._setColorOfTextOfCaretIndicator($caretIndicator);
   });
 }
 
@@ -120,7 +119,6 @@ caretIndicator.prototype._buildIndicator = function(user, position) {
     top: (position.top - INDICATOR_HEIGHT) + 'px',
   });
   this._setColorOf($indicator);
-  this._setColorOfTextOfCaretIndicator($indicator);
   return $indicator;
 }
 
@@ -129,6 +127,7 @@ caretIndicator.prototype._setColorOf = function($indicator) {
   $indicator.css({
     color: color,
   });
+  this._setColorOfTextOfCaretIndicator($indicator);
 }
 
 caretIndicator.prototype._getUserColorName = function($indicator) {

--- a/static/js/colors.js
+++ b/static/js/colors.js
@@ -21,7 +21,7 @@ exports.getColorHash = function(colorName, alpha) {
 // column we use a letter as prefix (A, B, C, D). The columns "A" and "C" are
 // the ones with colors with higher brightness
 exports.isColorLight = function(colorName) {
-  return colorName.startsWith('A') || colorName.startsWith('C');
+  return colorName && (colorName.startsWith('A') || colorName.startsWith('C'));
 }
 
 var COLORS_RGB = {


### PR DESCRIPTION
This PR fixes the bug of not keeping the user name font color when
user edits a text. 
To reproduce this error:
1. User 1 changes the color of User 2 for a light color*** (In this moment the User 2 color is correct - _black_)
2. User 2 writes something on the Editor  - the color is _white_

*** We need to change to a light color to force to have white letters.
This solution completes the solution implemented on https://github.com/storytouch/ep_cursortrace/pull/13

[Trello](https://trello.com/c/ugsBfX4b/1552-p3-multiplos-usu%C3%A1rios-setar-cor-do-tooltip-do-caret-do-usu%C3%A1rio-dependendo-da-cor-base)

