### PR TITLE
Fix flaky test

### DIFF
--- a/static/tests/frontend/specs/_utils.js
+++ b/static/tests/frontend/specs/_utils.js
@@ -77,8 +77,8 @@ ep_cursortrace_test_helper.utils = {
     // whole indicator 15px up. So we need to adjust its position when comparing to
     // an element on editor
     var actualCaretTop = caretPosition.top + 15;
-    var top  = actualCaretTop  - helperMarkPosition.top;
-    var left = caretPosition.left - helperMarkPosition.left;
+    var top  = Math.round(actualCaretTop  - helperMarkPosition.top);
+    var left = Math.round(caretPosition.left - helperMarkPosition.left);
 
     $helperMark.remove();
 


### PR DESCRIPTION
The tests were failing due to a small difference (expected was 0, received was 0.01) in the caret position. Therefore, in this PR we round the final calculated position.