### PR TITLE
[refactor] Prevents cursor message overload

### DIFF
--- a/messageDispatcher.js
+++ b/messageDispatcher.js
@@ -1,0 +1,90 @@
+var MAXIMUM_POSTPONEMENTS = 3;
+
+var messageDispatcher = function(dispatchFunction, dispatchInterval) {
+  this.dispatchFunction = dispatchFunction || function() {};
+  this.dispatchInterval = dispatchInterval || 0;
+  this.indexedBuffer = {};
+};
+
+messageDispatcher.prototype._registerMessage = function(key, message) {
+  var existingBufferRegister = this.indexedBuffer[key];
+  if (existingBufferRegister) {
+    // updates the message if the key already
+    // exists in the buffer. It leads us to
+    // consume only the most recent message with
+    // this key.
+    existingBufferRegister.message = message;
+  } else {
+    // if the key does not exists in the buffer yet,
+    // creates a new register
+    this.indexedBuffer[key] = {
+      message: message,
+      timeoutId: null,
+      postponementsCounter: 0,
+    };
+  }
+};
+
+messageDispatcher.prototype._consumeMessage = function(key) {
+  var bufferEntry = this.indexedBuffer[key];
+  var message = bufferEntry.message;
+  delete this.indexedBuffer[key];
+  return message;
+};
+
+/*
+ * This function will schedule the sending
+ * of a message according to its key.
+ * There may be three cases:
+ *
+ *  [1] A message with the given key was
+ *  not schedule before, then we schedule
+ *  it.
+ *
+ *  [2] A message with the given key was
+ *  already schedule before, so we postpone
+ *  its execution.
+ *
+ *  [3] A message with the given key was
+ *  already schedule before and was already
+ *  postponed the maximum number of times
+ *  allowed. So, we do not postpone it anymore.
+ */
+messageDispatcher.prototype._scheduleDispatch = function(key) {
+  var self = this;
+
+  var bufferEntry = self.indexedBuffer[key];
+  var previousScheduler = bufferEntry.timeoutId;
+  if (previousScheduler) {
+    var postponementsCounter = bufferEntry.postponementsCounter;
+    var shouldDispatchNow = postponementsCounter >= MAXIMUM_POSTPONEMENTS;
+    if (shouldDispatchNow) {
+      // if a max potsponement times was reached,
+      // do noting because the previous scheduler
+      // will dispatch the message [3]
+      return;
+    } else {
+      // cancel previous schedulers for this key
+      // and postpone the execution bellow [2]
+      bufferEntry.postponementsCounter += 1;
+      clearTimeout(previousScheduler);
+    }
+  }
+
+  // creates a new scheduler for this key [1]
+  var timeoutId = setTimeout(function() {
+    var message = self._consumeMessage(key);
+    self.dispatchFunction(message);
+  }, self.dispatchInterval);
+
+  bufferEntry.timeoutId = timeoutId;
+};
+
+messageDispatcher.prototype.dispatch = function(key, message) {
+  this._registerMessage(key, message);
+  this._scheduleDispatch(key);
+};
+
+exports.init = function(dispatchFunction, dispatchInterval) {
+  return new messageDispatcher(dispatchFunction, dispatchInterval);
+};

--- a/messageDispatcher.js
+++ b/messageDispatcher.js
@@ -19,7 +19,7 @@ messageDispatcher.prototype._registerMessage = function(key, message) {
     // creates a new register
     this.indexedBuffer[key] = {
       message: message,
-      timeoutId: null,
+      timeoutRef: null,
       postponementsCounter: 0,
     };
   }
@@ -54,7 +54,7 @@ messageDispatcher.prototype._scheduleDispatch = function(key) {
   var self = this;
 
   var bufferEntry = self.indexedBuffer[key];
-  var previousScheduler = bufferEntry.timeoutId;
+  var previousScheduler = bufferEntry.timeoutRef;
   if (previousScheduler) {
     var postponementsCounter = bufferEntry.postponementsCounter;
     var shouldDispatchNow = postponementsCounter >= MAXIMUM_POSTPONEMENTS;
@@ -72,12 +72,12 @@ messageDispatcher.prototype._scheduleDispatch = function(key) {
   }
 
   // creates a new scheduler for this key [1]
-  var timeoutId = setTimeout(function() {
+  var timeoutRef = setTimeout(function() {
     var message = self._consumeMessage(key);
     self.dispatchFunction(message);
   }, self.dispatchInterval);
 
-  bufferEntry.timeoutId = timeoutId;
+  bufferEntry.timeoutRef = timeoutRef;
 };
 
 messageDispatcher.prototype.dispatch = function(key, message) {

--- a/static/tests/backend/specs/messageDispatcher.js
+++ b/static/tests/backend/specs/messageDispatcher.js
@@ -1,0 +1,139 @@
+var assert = require('assert');
+var messageDispatcher = require('../../../../messageDispatcher');
+
+describe('Message Dispatcher', function() {
+  var messageDispatcherInstance, revisionNumber;
+
+  var dispatchedMessages = [];
+  var dispatchInterval = 50; // 50ms (milliseconds) 
+  var dispatchFunction = function(message) {
+    dispatchedMessages.push(message);
+  };
+
+  var resetDeliveredMessages = function() {
+    dispatchedMessages = [];
+  };
+
+  var sleep = function(time) {
+    return new Promise(function(resolve) {
+      setTimeout(resolve, time);
+    });
+  };
+
+  before(function() {
+    messageDispatcherInstance = messageDispatcher.init(dispatchFunction, dispatchInterval);
+  });
+
+  context('dispatch()', function() {
+    var messages = [];
+
+    var subject = async function(messagesToDispatch) {
+      for (var message of messagesToDispatch) {
+        await sleep(message.delay);
+        messageDispatcherInstance.dispatch(message.key, message);
+      }
+    };
+
+    beforeEach(function() {
+      resetDeliveredMessages();
+    });
+
+    context('when one message with a new key is dispatched', function() {
+      beforeEach(async function() {
+        messages = [{ key: 'k0', message: 'm 0', delay: 0 }];
+
+        await subject(messages);
+        await sleep(dispatchInterval);
+      });
+
+      it('dispatches the message', function() {
+        assert.deepEqual(dispatchedMessages, messages);
+      });
+    });
+
+    context('when two messages with different keys are dispatched within an interval lower than dispatchInterval', function() {
+      beforeEach(async function() {
+        messages = [
+          { key: 'k0', message: 'm 0', delay: 0 },
+          { key: 'k1', message: 'm 1', delay: 49 },
+        ];
+
+        await subject(messages);
+        await sleep(dispatchInterval);
+      });
+
+      it('dispatches both messages', function() {
+        assert.deepEqual(dispatchedMessages, messages);
+      });
+    });
+
+    context('when two messages with different keys are dispatched within an interval greater than or equal to dispatchInterval', function() {
+      beforeEach(async function() {
+        messages = [
+          { key: 'k0', message: 'm 0', delay: 0 },
+          { key: 'k1', message: 'm 1', delay: 50 },
+        ];
+
+        await subject(messages);
+        await sleep(dispatchInterval);
+      });
+
+      it('dispatches both messages', function() {
+        assert.deepEqual(dispatchedMessages, messages);
+      });
+    });
+
+    context('when two messages with the same key are dispatched within an interval lower than dispatchInterval', function() {
+      beforeEach(async function() {
+        messages = [
+          { key: 'k0', message: 'm 0', delay: 0 },
+          { key: 'k0', message: 'm 1', delay: 49 },
+        ];
+
+        await subject(messages);
+        await sleep(dispatchInterval);
+      });
+
+      it('dispatches only the last message', function() {
+        assert.deepEqual(dispatchedMessages, [messages[1]]);
+      });
+    });
+
+    context('when two messages with the same key are dispatched within an interval greater than or equal to dispatchInterval', function() {
+      beforeEach(async function() {
+        messages = [
+          { key: 'k0', message: 'm 0', delay: 0 },
+          { key: 'k0', message: 'm 1', delay: 50 },
+        ];
+
+        await subject(messages);
+        await sleep(dispatchInterval);
+      });
+
+      it('dispatches both messages', function() {
+        assert.deepEqual(dispatchedMessages, messages);
+      });
+    });
+
+    // simulates the case where messages could be postponed forever
+    context('when a number greater than MAXIMUM_POSTPONEMENTS of messages with the same key are dispatched within an interval lower than dispatchInterval', function() {
+      beforeEach(async function() {
+        messages = [
+          { key: 'k0', message: 'm 0', delay: 0  },
+          { key: 'k0', message: 'm 1', delay: 40 }, //  40ms passed, postponed 1x
+          { key: 'k0', message: 'm 2', delay: 40 }, //  80ms passed, postponed 2x
+          { key: 'k0', message: 'm 3', delay: 40 }, // 120ms passed, postponed 3x
+          { key: 'k0', message: 'm 4', delay: 40 }, // 160ms passed <- Must be dispatched
+          { key: 'k0', message: 'm 5', delay: 40 }, // 200ms passed <- Must be dispatched
+        ];
+
+        await subject(messages);
+        await sleep(dispatchInterval);
+      });
+
+      it('dispatches the message after MAXIMUM_POSTPONEMENTS is reached and the last message', function() {
+        assert.deepEqual(dispatchedMessages, [messages[4], messages[5]]);
+      });
+    });
+  });
+});

--- a/static/tests/frontend/specs/api-inbound.js
+++ b/static/tests/frontend/specs/api-inbound.js
@@ -27,11 +27,13 @@ describe('ep_cursortrace - api - inbound messages', function() {
 
   describe('GO_TO_CARET_OF_USER', function() {
     before(function(done) {
+      this.timeout(4000);
+
       // move caret of other user to the end of pad, so it is out of viewport
       var moveCaretOutOfViewport = function(done) {
         utils.placeCaretOfOtherUserAtEndOfLine(MULTIPLE_LINES - 1, done);
       }
-      utils.executeAndWaitForCaretIndicatorToMove(moveCaretOutOfViewport, done);
+      utils.executeAndWaitForCaretIndicatorToMove(moveCaretOutOfViewport, done, 2000);
     });
 
     context('when user requires to go to caret of other user', function() {

--- a/static/tests/frontend/specs/api-outbound.js
+++ b/static/tests/frontend/specs/api-outbound.js
@@ -14,11 +14,15 @@ describe('ep_cursortrace - api - outbound messages', function() {
   });
 
   it('sends both users on the list of users on pad for the other user', function(done) {
-    var usersOfOtherPad = apiUtils.getLastListOfUsersOnPadOf(utils.otherUserId);
-    expect(usersOfOtherPad.length).to.be(2);
-    expect(usersOfOtherPad).to.contain(utils.myUserId);
-    expect(usersOfOtherPad).to.contain(utils.otherUserId);
-    done();
+    helper.waitFor(function() {
+      var usersOfOtherPad = apiUtils.getLastListOfUsersOnPadOf(utils.otherUserId);
+      return usersOfOtherPad.length === 2;
+    }).done(function() {
+      var usersOfOtherPad = apiUtils.getLastListOfUsersOnPadOf(utils.otherUserId);
+      expect(usersOfOtherPad).to.contain(utils.myUserId);
+      expect(usersOfOtherPad).to.contain(utils.otherUserId);
+      done();
+    });
   });
 
   it('sends both users on the list of users on pad for this user', function(done) {

--- a/static/tests/frontend/specs/integration-ep_sm.js
+++ b/static/tests/frontend/specs/integration-ep_sm.js
@@ -47,12 +47,13 @@ describe('ep_cursortrace - integration with ep_script_scene_marks', function () 
     }
 
     it('shows caret indicator on beginning of line with heading', function(done) {
+      this.timeout(4000);
       utils.executeAndWaitForCaretIndicatorToMove(moveCaret, function() {
         var distance = utils.getDistanceBetweenCaretIndicatorAndBeginningOfLine(LINE_WITH_HEADING);
         expect(distance.left).to.be(0);
         expect(distance.top).to.be(0);
         done();
-      });
+      }, 2000);
     });
   });
 
@@ -62,12 +63,13 @@ describe('ep_cursortrace - integration with ep_script_scene_marks', function () 
     }
 
     it('updates the caret indicator for this user', function(done) {
+      this.timeout(4000);
       utils.executeAndWaitForCaretIndicatorToMove(moveCaret, function() {
         var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(LINE_AFTER_SM);
         expect(distance.left).to.be(0);
         expect(distance.top).to.be(0);
         done();
-      });
+      }, 2000);
     });
 
     context('and this user opens the SM', function() {
@@ -109,12 +111,13 @@ describe('ep_cursortrace - integration with ep_script_scene_marks', function () 
     }
 
     it('updates the caret indicator for this user', function(done) {
+      this.timeout(4000);
       utils.executeAndWaitForCaretIndicatorToMove(moveCaret, function() {
         helper.waitFor(function() {
           var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(LINE_BEFORE_SM);
           return distance.left === 0 && distance.top === 0;
         }).done(done);
-      });
+      }, 2000);
     });
 
     context('and this user opens the SM', function() {

--- a/static/tests/frontend/specs/integration-ep_toggle.js
+++ b/static/tests/frontend/specs/integration-ep_toggle.js
@@ -119,42 +119,45 @@ describe('ep_cursortrace - integration with ep_script_toggle_view', function () 
         utils.placeCaretOfOtherUserAtBeginningOfLine(LINE_WITH_SEQ_DESCRIPTION_1, done);
       };
 
-      utils.executeAndWaitForCaretIndicatorToMove(moveCaretToTheMiddleOfSequence, done);
+      utils.executeAndWaitForCaretIndicatorToMove(moveCaretToTheMiddleOfSequence, done, 4000);
     }
 
     var testCaretIndicatorIsOnSamePositionOfCaret = function(testConfig) {
       it('shows caret indicator on the exact position when the other user placed it', function(done) {
+        this.timeout(6000)
         var moveCaret = moveCaretOfOtherUserToLine(testConfig.lineNumber);
         utils.executeAndWaitForCaretIndicatorToMove(moveCaret, function() {
           var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(testConfig.lineNumber);
           expect(distance.left).to.be(0);
           expect(distance.top).to.be(0);
           done();
-        }, 1900);
+        }, 4000);
       });
     }
 
     var testCaretIndicatorIsAtBeginningOfSequenceTitle = function(testConfig) {
       it('shows caret indicator at the beginning of sequence title', function(done) {
+        this.timeout(6000)
         var moveCaret = moveCaretOfOtherUserToLine(testConfig.lineNumber);
         utils.executeAndWaitForCaretIndicatorToMove(moveCaret, function() {
           var distance = utils.getDistanceBetweenCaretIndicatorAndBeginningOfLine(LINE_WITH_SEQ_TITLE);
           expect(distance.left).to.be(0);
           expect(distance.top).to.be(0);
           done();
-        }, 1900);
+        }, 4000);
       });
     }
 
     var testCaretIndicatorIsAtEndOfSequenceDescription = function(testConfig) {
       it('shows caret indicator at the end of last line of sequence description', function(done) {
+        this.timeout(6000)
         var moveCaret = moveCaretOfOtherUserToLine(testConfig.lineNumber);
         utils.executeAndWaitForCaretIndicatorToMove(moveCaret, function() {
           var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(LINE_WITH_SEQ_DESCRIPTION_2);
           expect(distance.left).to.be(0);
           expect(distance.top).to.be(0);
           done();
-        }, 1900);
+        }, 4000);
       });
     }
 
@@ -166,10 +169,11 @@ describe('ep_cursortrace - integration with ep_script_toggle_view', function () 
     }
 
     before(function(done) {
+      this.timeout(4000);
       utils.openPadForMultipleUsers(this, createScript, function() {
         utils.waitForCaretIndicatorToBeVisibleForBothUsers(function() {
           // open SM for the other user, so all lines of the SM are visible
-          utils.executeAndWaitForCaretIndicatorToMove(openSM, done);
+          utils.executeAndWaitForCaretIndicatorToMove(openSM, done, 2000);
         });
       });
     });
@@ -196,6 +200,7 @@ describe('ep_cursortrace - integration with ep_script_toggle_view', function () 
       ].forEach(function(testConfig) {
           context('and line is ' + testConfig.description, function() {
             before(function(done) {
+              this.timeout(6000);
               forceCaretIndicatorToMove(done);
             });
 

--- a/static/tests/frontend/specs/tests.js
+++ b/static/tests/frontend/specs/tests.js
@@ -36,13 +36,14 @@ describe('ep_cursortrace - Basic Tests', function () {
     });
 
     it('updates the caret indicator for this user', function(done) {
+      this.timeout(4000);
       utils.executeAndWaitForCaretIndicatorToMove(moveCaret, function() {
         // caret is at the end of the line; caret indicator should be there too
         var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(TARGET_LINE);
         expect(distance.left).to.be(0);
         expect(distance.top).to.be(0);
         done();
-      });
+      }, 2000);
     });
   });
 
@@ -54,20 +55,20 @@ describe('ep_cursortrace - Basic Tests', function () {
     }
 
     before(function(done) {
-      this.timeout(5000);
+      this.timeout(8000);
       utils.waitForCaretIndicatorToBeVisibleForBothUsers(function() {
         makeSureCaretOfOtherUserIsAtEndOfLine(TARGET_LINE, done);
       });
     });
 
     it('updates the caret indicator of the other user', function(done) {
-      this.timeout(3000);
+      this.timeout(6000);
       utils.executeAndWaitForCaretIndicatorToMove(editLine, function() {
         var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(TARGET_LINE);
         expect(distance.left).to.be(0);
         expect(distance.top).to.be(0);
         done();
-      }, 2900);
+      }, 4000);
     });
   });
 
@@ -75,7 +76,7 @@ describe('ep_cursortrace - Basic Tests', function () {
     var originalPosition;
 
     before(function(done) {
-      this.timeout(4000);
+      this.timeout(6000);
       utils.waitForCaretIndicatorToBeVisibleForBothUsers(function() {
         originalPosition = utils.getCaretIndicatorPosition();
 
@@ -91,17 +92,18 @@ describe('ep_cursortrace - Basic Tests', function () {
 
           // [user 2] go back to the end of line
           utils.placeCaretOfOtherUserAtEndOfLine(TARGET_LINE, done);
-        });
+        }, 4000);
       });
     });
 
     it('does not affect caret indicator for this user', function(done) {
+      this.timeout(4000);
       utils.waitForCaretIndicatorToMove(originalPosition, function() {
         var distance = utils.getDistanceBetweenCaretIndicatorAndEndOfLine(TARGET_LINE);
         expect(distance.left).to.be(0);
         expect(distance.top).to.be(0);
         done();
-      });
+      }, 2000);
     });
   });
 
@@ -146,7 +148,7 @@ describe('ep_cursortrace - Basic Tests', function () {
           var distance = utils.getDistanceBetweenCaretIndicatorAndTarget($emptyLine);
           return distance.left === 0 && distance.top === 0;
         }).done(done);
-      });
+      }, 2000);
     });
   });
 
@@ -192,7 +194,7 @@ describe('ep_cursortrace - Basic Tests', function () {
     // move caret to middle of line, so we're able to detect when it is moved to the end
     // and caret indicator was updated
     utils.executeAndWaitForCaretIndicatorToMove(moveCaretToMiddleOfLine, function() {
-      utils.executeAndWaitForCaretIndicatorToMove(moveCaretToEndOfLine, done, 2000);
-    }, 2000);
+      utils.executeAndWaitForCaretIndicatorToMove(moveCaretToEndOfLine, done, 4000);
+    }, 4000);
   }
 });


### PR DESCRIPTION
This commit adds a message dispatcher that uses a buffer to store incoming messages and schedules their dispatching. It allows sending the most recent data instead of sending every incoming data, which can cause an overload through socket stream. It also helps to prevent DDoS attacks.

Implements the [card 2423](https://trello.com/c/5IplDLBn).