### PR TITLE
[fix] Fix splitText error

### DIFF
--- a/static/js/caret_position.js
+++ b/static/js/caret_position.js
@@ -89,6 +89,11 @@ var getNodeInfoWhereCaretIs = function(caretColumn, $caretDiv) {
 }
 
 var splitNodeOnCaretPosition = function(cloneTextNode, counter, caretColumn) {
+  // sometimes when there are other users editing the same pad, the split is
+  // called too early and the text is not sincronized with the caret yet, 
+  // so we don't need to split anything
+  if (cloneTextNode.length <= caretColumn) return cloneTextNode;
+
   // cloneTextNode is an empty line (the <br> inside the <div>), so we don't need to split anything
   if (cloneTextNode.nodeType !== Node.TEXT_NODE) return cloneTextNode;
 


### PR DESCRIPTION
This PR fixes the `splitText` error

<img width="852" alt="image" src="https://user-images.githubusercontent.com/5985312/96033786-f23c6800-0e36-11eb-9060-ab2344097c8e.png">

Sometimes when there are other users editing the same pad, the split is called too early and the text is not synchronized with the caret yet, so we don't need to split anything.

Implements the [card 2422](https://trello.com/c/Hj4taExr).
