### PR TITLE
[fix] Fix caret position on end of line

### DIFF
--- a/static/js/caret_position.js
+++ b/static/js/caret_position.js
@@ -92,7 +92,7 @@ var splitNodeOnCaretPosition = function(cloneTextNode, counter, caretColumn) {
   // sometimes when there are other users editing the same pad, the split is
   // called too early and the text is not sincronized with the caret yet, 
   // so we don't need to split anything
-  if (cloneTextNode.length <= caretColumn) return cloneTextNode;
+  if (cloneTextNode.length < caretColumn) return cloneTextNode;
 
   // cloneTextNode is an empty line (the <br> inside the <div>), so we don't need to split anything
   if (cloneTextNode.nodeType !== Node.TEXT_NODE) return cloneTextNode;


### PR DESCRIPTION
In this commit we fix an error that happened when the caret of the second
user is in the end of the line. In this case the first user sees the
other users' caret in the beginning of the line.

[Card link](https://trello.com/c/defRww1r/2533-n%C3%A3o-posiciona-o-cursor-do-usu%C3%A1rio-2-no-final-da-linha)